### PR TITLE
Add unified cache

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -574,12 +574,12 @@ void LocalServer::processConfig()
     /// Size of cache for uncompressed blocks of MergeTree indices. Zero means disabled.
     size_t index_uncompressed_cache_size = config().getUInt64("index_uncompressed_cache_size", 0);
     if (index_uncompressed_cache_size)
-        global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
+        global_context->setIndexUncompressedCache(index_uncompressed_cache_size, "");
 
     /// Size of cache for index marks (index of MergeTree skip indices).
     size_t index_mark_cache_size = config().getUInt64("index_mark_cache_size", 0);
     if (index_mark_cache_size)
-        global_context->setIndexMarkCache(index_mark_cache_size);
+        global_context->setIndexMarkCache(index_mark_cache_size, "");
 
     /// A cache for mmapped files.
     size_t mmap_cache_size = config().getUInt64("mmap_cache_size", 1000);   /// The choice of default is arbitrary.

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -11,6 +11,7 @@
 #include <Poco/Net/NetException.h>
 #include <Poco/Util/HelpFormatter.h>
 #include <Poco/Environment.h>
+#include "Common/HashTable/Hash.h"
 #include <Common/scope_guard_safe.h>
 #include <Common/logger_useful.h>
 #include <base/phdr_cache.h>
@@ -24,6 +25,7 @@
 #include <Common/MemoryTracker.h>
 #include <Common/ClickHouseRevision.h>
 #include <Common/DNSResolver.h>
+#include <Common/UnifiedCache.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/ConcurrencyControl.h>
 #include <Common/Macros.h>
@@ -653,6 +655,12 @@ int Server::main(const std::vector<std::string> & /*args*/)
     MainThreadStatus::getInstance();
 
     StackTrace::setShowAddresses(config().getBool("show_addresses_in_stack_traces", true));
+
+    const size_t buddy_arena_size = 2048 * (1ull << 20); // 2024 MB 
+    const size_t buddy_minimal_block_size = 16;
+    auto& buddy_instance = DB::BuddyArena::instance();
+    buddy_instance.initialize(buddy_minimal_block_size, buddy_arena_size);
+
 
 #if USE_HDFS
     /// This will point libhdfs3 to the right location for its config.
@@ -1393,12 +1401,15 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Set up caches.
 
+    auto& global_cache_instance = LRUUnifiedCacheGlobal<UInt128, UInt128TrivialHash>::instance();
+    global_cache_instance.initialize(buddy_arena_size);
+
     /// Lower cache size on low-memory systems.
     double cache_size_to_ram_max_ratio = config().getDouble("cache_size_to_ram_max_ratio", 0.5);
     size_t max_cache_size = static_cast<size_t>(memory_amount * cache_size_to_ram_max_ratio);
 
     /// Size of cache for uncompressed blocks. Zero means disabled.
-    String uncompressed_cache_policy = config().getString("uncompressed_cache_policy", "");
+    String uncompressed_cache_policy = config().getString("uncompressed_cache_policy", "UNIFIED");
     LOG_INFO(log, "Uncompressed cache policy name {}", uncompressed_cache_policy);
     size_t uncompressed_cache_size = config().getUInt64("uncompressed_cache_size", 0);
     if (uncompressed_cache_size > max_cache_size)
@@ -1425,7 +1436,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Size of cache for marks (index of MergeTree family of tables).
     size_t mark_cache_size = config().getUInt64("mark_cache_size", 5368709120);
-    String mark_cache_policy = config().getString("mark_cache_policy", "");
+    String mark_cache_policy = config().getString("mark_cache_policy", "UNIFIED");
     if (!mark_cache_size)
         LOG_ERROR(log, "Too low mark cache size will lead to severe performance degradation.");
     if (mark_cache_size > max_cache_size)

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -656,7 +656,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     StackTrace::setShowAddresses(config().getBool("show_addresses_in_stack_traces", true));
 
-    const size_t buddy_arena_size = 10_GiB;
+    const size_t buddy_arena_size = 32_GiB;
     const size_t buddy_minimal_block_size = 16;
     auto& buddy_instance = DB::BuddyArena::instance();
     buddy_instance.initialize(buddy_minimal_block_size, buddy_arena_size);
@@ -1415,7 +1415,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /// Size of cache for uncompressed blocks. Zero means disabled.
     String uncompressed_cache_policy = config().getString("uncompressed_cache_policy", "unified");
     LOG_INFO(log, "Uncompressed cache policy name {}", uncompressed_cache_policy);
-    size_t uncompressed_cache_size = config().getUInt64("uncompressed_cache_size", 0);
+    size_t uncompressed_cache_size = config().getUInt64("uncompressed_cache_size", 5368709120);
     if (uncompressed_cache_size > max_cache_size)
     {
         uncompressed_cache_size = max_cache_size;

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1454,12 +1454,12 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /// Size of cache for uncompressed blocks of MergeTree indices. Zero means disabled.
     size_t index_uncompressed_cache_size = config().getUInt64("index_uncompressed_cache_size", 0);
     if (index_uncompressed_cache_size)
-        global_context->setIndexUncompressedCache(index_uncompressed_cache_size);
+        global_context->setIndexUncompressedCache(index_uncompressed_cache_size, "unified");
 
     /// Size of cache for index marks (index of MergeTree skip indices).
     size_t index_mark_cache_size = config().getUInt64("index_mark_cache_size", 0);
     if (index_mark_cache_size)
-        global_context->setIndexMarkCache(index_mark_cache_size);
+        global_context->setIndexMarkCache(index_mark_cache_size, "unified");
 
     /// A cache for mmapped files.
     size_t mmap_cache_size = config().getUInt64("mmap_cache_size", 1000);   /// The choice of default is arbitrary.

--- a/src/Columns/ColumnVectorHelper.h
+++ b/src/Columns/ColumnVectorHelper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/IColumn.h>
+#include "Common/UnifiedCache.h"
 #include <Common/PODArray.h>
 
 
@@ -28,13 +29,13 @@ public:
     template <size_t ELEMENT_SIZE>
     const char * getRawDataBegin() const
     {
-        return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, 15, 16> *>(reinterpret_cast<const char *>(this) + sizeof(*this))->raw_data();
+        return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, BuddyAllocator, 15, 16> *>(reinterpret_cast<const char *>(this) + sizeof(*this))->raw_data();
     }
 
     template <size_t ELEMENT_SIZE>
     void insertRawData(const char * ptr)
     {
-        return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, 15, 16> *>(reinterpret_cast<char *>(this) + sizeof(*this))->push_back_raw(ptr);
+        return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, BuddyAllocator, 15, 16> *>(reinterpret_cast<char *>(this) + sizeof(*this))->push_back_raw(ptr);
     }
 };
 

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -121,6 +121,23 @@ public:
             /// nothing to do.
             /// BTW, it's not possible to change alignment while doing realloc.
         }
+        /// TODO: Remove hardcoded constant, only for temporary tests of base Allocator replacement
+        // else if (alignment <= MALLOC_MIN_ALIGNMENT)
+        else if (old_size < DB::UNIFIED_ALLOC_THRESHOLD && new_size < DB::UNIFIED_ALLOC_THRESHOLD 
+                 && alignment <= 8)
+        {
+            /// Resize malloc'd memory region with no special alignment requirement.
+            CurrentMemoryTracker::realloc(old_size, new_size);
+
+            void * new_buf = ::realloc(buf, new_size);
+            if (nullptr == new_buf)
+                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot realloc from {} to {}.", ReadableSize(old_size), ReadableSize(new_size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+            buf = new_buf;
+            if constexpr (clear_memory)
+                if (new_size > old_size)
+                    memset(reinterpret_cast<char *>(buf) + old_size, 0, new_size - old_size);
+        }
         else
         {
             /// Big allocs that requires a copy. MemoryTracker is called inside 'alloc', 'free' methods.

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <cstring>
+#include <Poco/Logger.h>
+#include "Common/logger_useful.h"
+
+#include <Common/UnifiedCache.h>
 
 #ifdef NDEBUG
     #define ALLOCATOR_ASLR 0
@@ -74,40 +78,30 @@ namespace ErrorCodes
 }
 }
 
-/** Responsible for allocating / freeing memory. Used, for example, in PODArray, Arena.
-  * Also used in hash tables.
-  * The interface is different from std::allocator
-  * - the presence of the method realloc, which for large chunks of memory uses mremap;
-  * - passing the size into the `free` method;
-  * - by the presence of the `alignment` argument;
-  * - the possibility of zeroing memory (used in hash tables);
-  * - random hint address for mmap
-  * - mmap_threshold for using mmap less or more
-  */
+/// TODO: Remove BuddyAllocator replacement for the base Allocator class
+/// This is only for initial benchmarking pusposes
 template <bool clear_memory_, bool mmap_populate>
-class Allocator
+class Allocator 
 {
 public:
     /// Allocate memory range.
-    void * alloc(size_t size, size_t alignment = 0)
+    static void * alloc(size_t size, size_t alignment = 0)
     {
         checkSize(size);
-        CurrentMemoryTracker::alloc(size);
         return allocNoTrack(size, alignment);
     }
 
     /// Free memory range.
-    void free(void * buf, size_t size)
+    static void free(void * buf, size_t size)
     {
         try
         {
             checkSize(size);
             freeNoTrack(buf, size);
-            CurrentMemoryTracker::free(size);
         }
         catch (...)
         {
-            DB::tryLogCurrentException("Allocator::free");
+            DB::tryLogCurrentException("BuddyAllocator::free");
             throw;
         }
     }
@@ -116,7 +110,7 @@ public:
       * Data from old range is moved to the beginning of new range.
       * Address of memory range could change.
       */
-    void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0)
+    static void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0)
     {
         checkSize(new_size);
 
@@ -124,45 +118,6 @@ public:
         {
             /// nothing to do.
             /// BTW, it's not possible to change alignment while doing realloc.
-        }
-        else if (old_size < MMAP_THRESHOLD && new_size < MMAP_THRESHOLD
-                 && alignment <= MALLOC_MIN_ALIGNMENT)
-        {
-            /// Resize malloc'd memory region with no special alignment requirement.
-            CurrentMemoryTracker::realloc(old_size, new_size);
-
-            void * new_buf = ::realloc(buf, new_size);
-            if (nullptr == new_buf)
-                DB::throwFromErrno(fmt::format("Allocator: Cannot realloc from {} to {}.", ReadableSize(old_size), ReadableSize(new_size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-
-            buf = new_buf;
-            if constexpr (clear_memory)
-                if (new_size > old_size)
-                    memset(reinterpret_cast<char *>(buf) + old_size, 0, new_size - old_size);
-        }
-        else if (old_size >= MMAP_THRESHOLD && new_size >= MMAP_THRESHOLD)
-        {
-            /// Resize mmap'd memory region.
-            CurrentMemoryTracker::realloc(old_size, new_size);
-
-            // On apple and freebsd self-implemented mremap used (common/mremap.h)
-            buf = clickhouse_mremap(buf, old_size, new_size, MREMAP_MAYMOVE,
-                                    PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
-            if (MAP_FAILED == buf)
-                DB::throwFromErrno(fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
-                    ReadableSize(old_size), ReadableSize(new_size)), DB::ErrorCodes::CANNOT_MREMAP);
-
-            /// No need for zero-fill, because mmap guarantees it.
-        }
-        else if (new_size < MMAP_THRESHOLD)
-        {
-            /// Small allocs that requires a copy. Assume there's enough memory in system. Call CurrentMemoryTracker once.
-            CurrentMemoryTracker::realloc(old_size, new_size);
-
-            void * new_buf = allocNoTrack(new_size, alignment);
-            memcpy(new_buf, buf, std::min(old_size, new_size));
-            freeNoTrack(buf, old_size);
-            buf = new_buf;
         }
         else
         {
@@ -185,101 +140,277 @@ protected:
 
     static constexpr bool clear_memory = clear_memory_;
 
-    // Freshly mmapped pages are copy-on-write references to a global zero page.
-    // On the first write, a page fault occurs, and an actual writable page is
-    // allocated. If we are going to use this memory soon, such as when resizing
-    // hash tables, it makes sense to pre-fault the pages by passing
-    // MAP_POPULATE to mmap(). This takes some time, but should be faster
-    // overall than having a hot loop interrupted by page faults.
-    // It is only supported on Linux.
-    static constexpr int mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS
-#if defined(OS_LINUX)
-        | (mmap_populate ? MAP_POPULATE : 0)
-#endif
-        ;
-
 private:
-    void * allocNoTrack(size_t size, size_t alignment)
-    {
-        void * buf;
-        size_t mmap_min_alignment = ::getPageSize();
-
-        if (size >= MMAP_THRESHOLD)
-        {
-            if (alignment > mmap_min_alignment)
-                throw DB::Exception(fmt::format("Too large alignment {}: more than page size when allocating {}.",
-                    ReadableSize(alignment), ReadableSize(size)), DB::ErrorCodes::BAD_ARGUMENTS);
-
-            buf = mmap(getMmapHint(), size, PROT_READ | PROT_WRITE,
-                       mmap_flags, -1, 0);
-            if (MAP_FAILED == buf)
-                DB::throwFromErrno(fmt::format("Allocator: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-
-            /// No need for zero-fill, because mmap guarantees it.
-        }
-        else
-        {
-            if (alignment <= MALLOC_MIN_ALIGNMENT)
-            {
-                if constexpr (clear_memory)
-                    buf = ::calloc(size, 1);
-                else
-                    buf = ::malloc(size);
-
-                if (nullptr == buf)
-                    DB::throwFromErrno(fmt::format("Allocator: Cannot malloc {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-            }
-            else
-            {
-                buf = nullptr;
-                int res = posix_memalign(&buf, alignment, size);
-
-                if (0 != res)
-                    DB::throwFromErrno(fmt::format("Cannot allocate memory (posix_memalign) {}.", ReadableSize(size)),
-                        DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, res);
-
-                if constexpr (clear_memory)
-                    memset(buf, 0, size);
-            }
-        }
-        return buf;
-    }
-
-    void freeNoTrack(void * buf, size_t size)
-    {
-        if (size >= MMAP_THRESHOLD)
-        {
-            if (0 != munmap(buf, size))
-                DB::throwFromErrno(fmt::format("Allocator: Cannot munmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_MUNMAP);
-        }
-        else
-        {
-            ::free(buf);
-        }
-    }
-
-    void checkSize(size_t size)
+    static void checkSize(size_t size)
     {
         /// More obvious exception in case of possible overflow (instead of just "Cannot mmap").
         if (size >= 0x8000000000000000ULL)
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Too large size ({}) passed to allocator. It indicates an error.", size);
     }
 
-#ifndef NDEBUG
-    /// In debug builds, request mmap() at random addresses (a kind of ASLR), to
-    /// reproduce more memory stomping bugs. Note that Linux doesn't do it by
-    /// default. This may lead to worse TLB performance.
-    void * getMmapHint()
+    static void * allocNoTrack(size_t size, size_t alignment = 0) 
     {
-        return reinterpret_cast<void *>(std::uniform_int_distribution<intptr_t>(0x100000000000UL, 0x700000000000UL)(thread_local_rng));
+        auto & instance = DB::BuddyArena::instance();
+        void * buf = nullptr;
+        if (instance.isValid()) 
+        {
+            buf = instance.malloc(size, alignment);
+
+            if (nullptr == buf)
+                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot allocate memory (BuddyArena) {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+            if constexpr (clear_memory)
+                memset(buf, 0, size);
+        }
+        else if (alignment <= MALLOC_MIN_ALIGNMENT)
+        {
+            if constexpr (clear_memory)
+                buf = ::calloc(size, 1);
+            else
+                buf = ::malloc(size);
+
+            if (nullptr == buf)
+                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot malloc {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+        }
+        else
+        {
+            buf = nullptr;
+            int res = posix_memalign(&buf, alignment, size);
+
+            if (0 != res)
+                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot allocate memory (posix_memalign) {}.", ReadableSize(size)),
+                    DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, res);
+
+            if constexpr (clear_memory)
+                memset(buf, 0, size);
+        }
+
+        return buf;
     }
-#else
-    void * getMmapHint()
+
+    static void freeNoTrack(void * buf, size_t size)
     {
-        return nullptr;
+        if (nullptr == buf) {
+            return;
+        }
+
+        auto & instance = DB::BuddyArena::instance();
+        if (instance.isValid() && instance.isAllocated(buf)) 
+            instance.free(buf, size);
+        else
+            ::free(buf);
     }
-#endif
 };
+
+/** Responsible for allocating / freeing memory. Used, for example, in PODArray, Arena.
+  * Also used in hash tables.
+  * The interface is different from std::allocator
+  * - the presence of the method realloc, which for large chunks of memory uses mremap;
+  * - passing the size into the `free` method;
+  * - by the presence of the `alignment` argument;
+  * - the possibility of zeroing memory (used in hash tables);
+  * - random hint address for mmap
+  * - mmap_threshold for using mmap less or more
+  */
+// template <bool clear_memory_, bool mmap_populate>
+// class Allocator
+// {
+// public:
+//     /// Allocate memory range.
+//     void * alloc(size_t size, size_t alignment = 0)
+//     {
+//         checkSize(size);
+//         CurrentMemoryTracker::alloc(size);
+//         return allocNoTrack(size, alignment);
+//     }
+
+//     /// Free memory range.
+//     void free(void * buf, size_t size)
+//     {
+//         try
+//         {
+//             checkSize(size);
+//             freeNoTrack(buf, size);
+//             CurrentMemoryTracker::free(size);
+//         }
+//         catch (...)
+//         {
+//             DB::tryLogCurrentException("Allocator::free");
+//             throw;
+//         }
+//     }
+
+//     /** Enlarge memory range.
+//       * Data from old range is moved to the beginning of new range.
+//       * Address of memory range could change.
+//       */
+//     void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0)
+//     {
+//         checkSize(new_size);
+
+//         if (old_size == new_size)
+//         {
+//             /// nothing to do.
+//             /// BTW, it's not possible to change alignment while doing realloc.
+//         }
+//         else if (old_size < MMAP_THRESHOLD && new_size < MMAP_THRESHOLD
+//                  && alignment <= MALLOC_MIN_ALIGNMENT)
+//         {
+//             /// Resize malloc'd memory region with no special alignment requirement.
+//             CurrentMemoryTracker::realloc(old_size, new_size);
+
+//             void * new_buf = ::realloc(buf, new_size);
+//             if (nullptr == new_buf)
+//                 DB::throwFromErrno(fmt::format("Allocator: Cannot realloc from {} to {}.", ReadableSize(old_size), ReadableSize(new_size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+//             buf = new_buf;
+//             if constexpr (clear_memory)
+//                 if (new_size > old_size)
+//                     memset(reinterpret_cast<char *>(buf) + old_size, 0, new_size - old_size);
+//         }
+//         else if (old_size >= MMAP_THRESHOLD && new_size >= MMAP_THRESHOLD)
+//         {
+//             /// Resize mmap'd memory region.
+//             CurrentMemoryTracker::realloc(old_size, new_size);
+
+//             // On apple and freebsd self-implemented mremap used (common/mremap.h)
+//             buf = clickhouse_mremap(buf, old_size, new_size, MREMAP_MAYMOVE,
+//                                     PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
+//             if (MAP_FAILED == buf)
+//                 DB::throwFromErrno(fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
+//                     ReadableSize(old_size), ReadableSize(new_size)), DB::ErrorCodes::CANNOT_MREMAP);
+
+//             /// No need for zero-fill, because mmap guarantees it.
+//         }
+//         else if (new_size < MMAP_THRESHOLD)
+//         {
+//             /// Small allocs that requires a copy. Assume there's enough memory in system. Call CurrentMemoryTracker once.
+//             CurrentMemoryTracker::realloc(old_size, new_size);
+
+//             void * new_buf = allocNoTrack(new_size, alignment);
+//             memcpy(new_buf, buf, std::min(old_size, new_size));
+//             freeNoTrack(buf, old_size);
+//             buf = new_buf;
+//         }
+//         else
+//         {
+//             /// Big allocs that requires a copy. MemoryTracker is called inside 'alloc', 'free' methods.
+
+//             void * new_buf = alloc(new_size, alignment);
+//             memcpy(new_buf, buf, std::min(old_size, new_size));
+//             free(buf, old_size);
+//             buf = new_buf;
+//         }
+
+//         // LOG_INFO(&Poco::Logger::get("UnifiedCache"), "Allocator: Reallocate buffer {} with old size {} and new size {} (do realloc)", buf, ReadableSize(old_size), ReadableSize(new_size));
+
+//         return buf;
+//     }
+
+// protected:
+//     static constexpr size_t getStackThreshold()
+//     {
+//         return 0;
+//     }
+
+//     static constexpr bool clear_memory = clear_memory_;
+
+//     // Freshly mmapped pages are copy-on-write references to a global zero page.
+//     // On the first write, a page fault occurs, and an actual writable page is
+//     // allocated. If we are going to use this memory soon, such as when resizing
+//     // hash tables, it makes sense to pre-fault the pages by passing
+//     // MAP_POPULATE to mmap(). This takes some time, but should be faster
+//     // overall than having a hot loop interrupted by page faults.
+//     // It is only supported on Linux.
+//     static constexpr int mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS
+// #if defined(OS_LINUX)
+//         | (mmap_populate ? MAP_POPULATE : 0)
+// #endif
+//         ;
+
+// private:
+//     void * allocNoTrack(size_t size, size_t alignment)
+//     {
+//         void * buf;
+//         size_t mmap_min_alignment = ::getPageSize();
+
+//         if (size >= MMAP_THRESHOLD)
+//         {
+//             if (alignment > mmap_min_alignment)
+//                 throw DB::Exception(fmt::format("Too large alignment {}: more than page size when allocating {}.",
+//                     ReadableSize(alignment), ReadableSize(size)), DB::ErrorCodes::BAD_ARGUMENTS);
+
+//             buf = mmap(getMmapHint(), size, PROT_READ | PROT_WRITE,
+//                        mmap_flags, -1, 0);
+//             if (MAP_FAILED == buf)
+//                 DB::throwFromErrno(fmt::format("Allocator: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+//             /// No need for zero-fill, because mmap guarantees it.
+//         }
+//         else
+//         {
+//             if (alignment <= MALLOC_MIN_ALIGNMENT)
+//             {
+//                 if constexpr (clear_memory)
+//                     buf = ::calloc(size, 1);
+//                 else
+//                     buf = ::malloc(size);
+
+//                 if (nullptr == buf)
+//                     DB::throwFromErrno(fmt::format("Allocator: Cannot malloc {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+//             }
+//             else
+//             {
+//                 buf = nullptr;
+//                 int res = posix_memalign(&buf, alignment, size);
+
+//                 if (0 != res)
+//                     DB::throwFromErrno(fmt::format("Cannot allocate memory (posix_memalign) {}.", ReadableSize(size)),
+//                         DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, res);
+
+//                 if constexpr (clear_memory)
+//                     memset(buf, 0, size);
+//             }
+//         }
+//         // LOG_INFO(&Poco::Logger::get("UnifiedCache"), "Allocator: Allocate buffer {} with size {}", buf, ReadableSize(size));
+//         return buf;
+//     }
+
+//     void freeNoTrack(void * buf, size_t size)
+//     {
+//         if (size >= MMAP_THRESHOLD)
+//         {
+//             if (0 != munmap(buf, size))
+//                 DB::throwFromErrno(fmt::format("Allocator: Cannot munmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_MUNMAP);
+//         }
+//         else
+//         {
+//             ::free(buf);
+//         }
+//     }
+
+//     void checkSize(size_t size)
+//     {
+//         /// More obvious exception in case of possible overflow (instead of just "Cannot mmap").
+//         if (size >= 0x8000000000000000ULL)
+//             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Too large size ({}) passed to allocator. It indicates an error.", size);
+//     }
+
+// #ifndef NDEBUG
+//     /// In debug builds, request mmap() at random addresses (a kind of ASLR), to
+//     /// reproduce more memory stomping bugs. Note that Linux doesn't do it by
+//     /// default. This may lead to worse TLB performance.
+//     void * getMmapHint()
+//     {
+//         return reinterpret_cast<void *>(std::uniform_int_distribution<intptr_t>(0x100000000000UL, 0x700000000000UL)(thread_local_rng));
+//     }
+// #else
+//     void * getMmapHint()
+//     {
+//         return nullptr;
+//     }
+// #endif
+// };
 
 
 /** Allocator with optimization to place small memory ranges in automatic memory.

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -57,7 +57,7 @@ public:
             using SLRUPolicy = SLRUCachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
             cache_policy = std::make_unique<SLRUPolicy>(max_size, max_elements_size, size_ratio, on_weight_loss_function);
         }
-        else if (cache_policy_name == "UNIFIED")
+        else if (cache_policy_name == "unified")
         {
             using UnifiedPolicy = LRUUnifiedCachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
             cache_policy = std::make_unique<UnifiedPolicy>(max_size, max_elements_size, on_weight_loss_function);

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Common/UnifiedCache.h"
 #include <Common/Exception.h>
 #include <Common/ICachePolicy.h>
 #include <Common/LRUCachePolicy.h>
@@ -55,6 +56,11 @@ public:
         {
             using SLRUPolicy = SLRUCachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
             cache_policy = std::make_unique<SLRUPolicy>(max_size, max_elements_size, size_ratio, on_weight_loss_function);
+        }
+        else if (cache_policy_name == "UNIFIED")
+        {
+            using UnifiedPolicy = LRUUnifiedCachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
+            cache_policy = std::make_unique<UnifiedPolicy>(max_size, max_elements_size, on_weight_loss_function);
         }
         else
         {

--- a/src/Common/HashTable/HashTableAllocator.h
+++ b/src/Common/HashTable/HashTableAllocator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Common/UnifiedCache.h"
 #include <Common/Allocator.h>
 
 
@@ -8,7 +9,8 @@
   * table, so it makes sense to pre-fault the pages so that page faults don't
   * interrupt the resize loop. Set the allocator parameter accordingly.
   */
-using HashTableAllocator = Allocator<true /* clear_memory */, true /* mmap_populate */>;
+// using HashTableAllocator = Allocator<true /* clear_memory */, true /* mmap_populate */>;
+using HashTableAllocator = DB::BuddyAllocator;
 
 template <size_t initial_bytes = 64>
 using HashTableAllocatorWithStackMemory = AllocatorWithStackMemory<HashTableAllocator, initial_bytes>;

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -11,6 +11,8 @@
 #include <base/strong_typedef.h>
 #include <base/getPageSize.h>
 
+#include "Common/formatReadable.h"
+#include "Common/logger_useful.h"
 #include <Common/Allocator.h>
 #include <Common/Exception.h>
 #include <Common/BitHelpers.h>
@@ -133,12 +135,19 @@ protected:
     {
         char * allocated = reinterpret_cast<char *>(TAllocator::alloc(bytes, std::forward<TAllocatorParams>(allocator_params)...));
 
+        // void * allocated_ptr = reinterpret_cast<void *>(allocated);
+        // const auto * type_name = typeid(TAllocator).name();
+        // LOG_DEBUG(&Poco::Logger::get("UnifiedCache"), "POD: Alloc {} in the {} with size {}", allocated_ptr, type_name, ReadableSize(bytes));
+
         c_start = allocated + pad_left;
         c_end = c_start;
         c_end_of_storage = allocated + bytes - pad_right;
 
         if (pad_left)
             memset(c_start - ELEMENT_SIZE, 0, ELEMENT_SIZE);
+
+        // auto * c_start_minus_pad_ptr = reinterpret_cast<void *>(c_start - pad_left);
+        // LOG_DEBUG(&Poco::Logger::get("UnifiedCache"), "POD: alloc in the {} c_start - pad_left = {}", type_name, c_start_minus_pad_ptr);
     }
 
     void dealloc()
@@ -147,6 +156,10 @@ protected:
             return;
 
         unprotect();
+
+        // void * dealloc_ptr = reinterpret_cast<void *>(c_start - pad_left);
+        // const auto * type_name = typeid(TAllocator).name();
+        // LOG_DEBUG(&Poco::Logger::get("UnifiedCache"), "POD: Dealloc {} in the {}", dealloc_ptr, type_name);
 
         TAllocator::free(c_start - pad_left, allocated_bytes());
     }
@@ -166,10 +179,17 @@ protected:
 
         char * allocated = reinterpret_cast<char *>(
             TAllocator::realloc(c_start - pad_left, allocated_bytes(), bytes, std::forward<TAllocatorParams>(allocator_params)...));
+            
+        // void * realloc_ptr = reinterpret_cast<void *>(allocated);
+        // const auto * type_name = typeid(TAllocator).name();
+        // LOG_DEBUG(&Poco::Logger::get("UnifiedCache"), "POD: Realloc {} in the {} with size {} and new size {}", realloc_ptr, type_name, ReadableSize(bytes), ReadableSize(allocated_bytes()));
 
         c_start = allocated + pad_left;
         c_end = c_start + end_diff;
         c_end_of_storage = allocated + bytes - pad_right;
+
+        // auto * c_start_minus_pad_ptr = reinterpret_cast<void *>(c_start - pad_left);
+        // LOG_DEBUG(&Poco::Logger::get("UnifiedCache"), "POD: realloc in the {} c_start - pad_left = {}", type_name, c_start_minus_pad_ptr);
     }
 
     bool isInitialized() const

--- a/src/Common/PODArray_fwd.h
+++ b/src/Common/PODArray_fwd.h
@@ -5,6 +5,7 @@
   */
 
 #include <base/types.h>
+#include "Common/UnifiedCache.h"
 #include <Common/Allocator_fwd.h>
 
 namespace DB
@@ -16,12 +17,12 @@ inline constexpr size_t integerRoundUp(size_t value, size_t dividend)
 }
 
 template <typename T, size_t initial_bytes = 4096,
-          typename TAllocator = Allocator<false>, size_t pad_right_ = 0,
+          typename TAllocator = BuddyAllocator, size_t pad_right_ = 0,
           size_t pad_left_ = 0>
 class PODArray;
 
 /** For columns. Padding is enough to read and write xmm-register at the address of the last element. */
-template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+template <typename T, size_t initial_bytes = 4096, typename TAllocator = BuddyAllocator>
 using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 15, 16>;
 
 /** A helper for declaring PODArray that uses inline memory.
@@ -31,6 +32,6 @@ using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 15, 16>;
 template <typename T, size_t inline_bytes,
           size_t rounded_bytes = integerRoundUp(inline_bytes, sizeof(T))>
 using PODArrayWithStackMemory = PODArray<T, rounded_bytes,
-    AllocatorWithStackMemory<Allocator<false>, rounded_bytes, alignof(T)>>;
+    AllocatorWithStackMemory<BuddyAllocator, rounded_bytes, alignof(T)>>;
 
 }

--- a/src/Common/UnifiedCache.cpp
+++ b/src/Common/UnifiedCache.cpp
@@ -1,0 +1,524 @@
+#include "UnifiedCache.h"
+#include "Common/HashTable/Hash.h"
+
+namespace DB {
+
+extern const size_t UNIFIED_ALLOC_THRESHOLD = static_cast<size_t>(10) * 1024 * 1024 * 1024;
+
+BuddyArena::~BuddyArena() noexcept
+{
+    if (isValid())
+        // Do not throw exceptions from invalid munmap
+        munmap(arena_buffer, total_size_bytes);
+}
+
+bool BuddyArena::isValid() const
+{
+    return number_of_levels != 0;
+}
+
+bool BuddyArena::isAllocated(const void *ptr) const
+{
+    const auto * arena_end = reinterpret_cast<char *>(arena_buffer) + total_size_bytes;
+    return ptr >= arena_buffer && ptr < reinterpret_cast<const void *>(arena_end); 
+}
+
+void BuddyArena::initialize(size_t minimal_allocation_size, size_t size)
+{
+    /// We will divide the whole size bytes on blocks with size == minimal_allocation_size
+    assert(size % minimal_allocation_size == 0);
+
+    total_size_bytes = size;
+    number_of_levels = 1;
+    minimal_allocation_size_bytes = minimal_allocation_size;
+
+    /// Calculate number of levels
+    size_t number_of_blocks_on_level = size / minimal_allocation_size; 
+
+    /// Number of blocks on the level could not be the power of 2
+    /// In this case we intentionally add one level to the binary tree so we'll have enough 
+    /// leaves to store all minimal blocks
+    if (number_of_blocks_on_level > 1 && number_of_blocks_on_level % 2 != 0) 
+        ++number_of_levels;
+
+    while (number_of_blocks_on_level > 1) 
+    {
+        number_of_blocks_on_level >>= 1;
+        ++number_of_levels;
+    }
+
+    /// Calculate number of minimal blocks in the memory arena
+    min_blocks_num = (1ull << (number_of_levels - 1));
+    free_min_blocks = min_blocks_num;
+
+    arena_buffer = allocateArena(total_size_bytes);
+
+    auto * current_storage_ptr = initializeMetaStorage();
+
+
+    // TODO: Optimize
+    /// Initialize free_lists
+
+    /// Calculate number of blocks for the meta storage
+    size_t meta_storage_size_minimal_blocks = (current_storage_ptr - reinterpret_cast<char *>(arena_buffer)) / minimal_allocation_size_bytes;
+
+    /// Calculate the nearest power of 2 that is greater than meta storage size
+    size_t meta_storage_size_round_up_to_power_of_2 = 1;
+    while (meta_storage_size_round_up_to_power_of_2 < meta_storage_size_minimal_blocks) 
+    {
+        meta_storage_size_round_up_to_power_of_2 *= 2;
+    }
+
+    /// Deallocate minimal blocks to fill the space between the meta storage and the size that is
+    /// the nearest power of 2, so after it we can deallocate blocks with an exponential increasing sizes 
+    /// Arena buffer:
+    /// [*******-------------|------------------------------------]
+    ///  |               |   |
+    ///  ^ meta storage  |   ^ meta_storage_size_round_up_to_power_of_2
+    ///                  ^ deallocate these blocks on this step
+    const auto * minimal_blocks_area_end = reinterpret_cast<char *>(arena_buffer) + meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size_bytes;
+    while (current_storage_ptr != minimal_blocks_area_end) 
+    {
+        deallocateBlock(reinterpret_cast<MemoryBlock *>(current_storage_ptr), number_of_levels - 1);
+        current_storage_ptr += minimal_allocation_size_bytes;
+    }
+
+    /// Deallocate all next blocks after meta_storage_size_round_up_to_power_of_2 with increasing sizes 
+    size_t current_block_size_bytes = meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size;
+    size_t current_block_level = calculateLevel(current_block_size_bytes);
+    while (current_block_level > 0) 
+    {
+        deallocateBlock(reinterpret_cast<MemoryBlock *>(current_storage_ptr), current_block_level);
+        current_storage_ptr += current_block_size_bytes;
+        current_block_size_bytes *= 2;
+        --current_block_level;
+    }
+}
+
+void * BuddyArena::malloc(size_t size, size_t align)
+{
+    /// TODO: Add assertion
+    /// assert that align is a power of 2 and a multiple of sizeof(void*) 
+    /// https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
+
+    auto level = calculateLevel(size, align);
+
+    std::lock_guard lock(mutex);
+    auto * block = allocateBlock(level);
+    setPointerLevel(block, level);
+
+    /// TODO: Remove temp local dummy memory tracker
+    const size_t allocated_memory_blocks = 1ull << ((number_of_levels - level) - 1);
+    free_min_blocks.fetch_sub(allocated_memory_blocks);
+    // if (free_min_blocks % 10000 == 0) {
+    //     printMemoryUsageDummy();
+    // }
+
+    return block->data;
+}
+
+void BuddyArena::free(void * buf) noexcept
+{
+    auto * block = reinterpret_cast<MemoryBlock *>(buf);
+    auto level = getPointerLevel(block);
+
+    std::lock_guard lock(mutex);
+    deallocateBlock(block, level);
+
+    /// TODO: Remove temp local dummy memory tracker
+    const size_t freeing_memory_blocks = 1ull << ((number_of_levels - level) - 1);
+    free_min_blocks.fetch_add(freeing_memory_blocks);
+    // if (free_min_blocks % 10000 == 0) {
+    //     printMemoryUsageDummy();
+    // }
+}
+
+double BuddyArena::getFreeSpaceRatio() const
+{
+    /// TODO: Change seq_cst memory_order on the free_min_blocks atomic
+    auto occupied_blocks = min_blocks_num - free_min_blocks.load();
+    return static_cast<double>(min_blocks_num - occupied_blocks) / min_blocks_num;
+}
+
+size_t BuddyArena::getTotalSizeBytes() const
+{
+    return total_size_bytes;
+}
+
+void * BuddyArena::allocateArena(size_t size)
+{
+    void * buffer = mmap(nullptr, size, PROT_READ | PROT_WRITE, 
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, /*fd=*/ -1, /*offset=*/ 0);
+    if (MAP_FAILED == buffer)
+        DB::throwFromErrno(fmt::format("BuddyArena: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+    /// TODO: Remove temporary hack to make the memory tracker works
+    /// As we allocated the memory arena, we don't want to take it into account in the 
+    /// memory tracker
+    // CurrentMemoryTracker::free(size);
+
+    return buffer;
+}
+
+void BuddyArena::deallocateArena(void * buffer, size_t size) 
+{
+    // TODO: Not checking the result value
+    munmap(buffer, size);
+}
+
+size_t BuddyArena::calculateLevel(size_t size) const 
+{
+    // TODO: optimize
+    size_t current_level = number_of_levels - 1;
+    size_t current_block_size = calculateBlockSizeOnLevel(current_level);
+
+    while (size > current_block_size) 
+    {
+        // Low in memory
+        if (current_level == 0) 
+            DB::throwFromErrno(fmt::format("BuddyArena: Cannot find level for size {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+        --current_level;
+        current_block_size *= 2;
+    }
+
+    return current_level;
+}
+
+size_t BuddyArena::calculateLevel(size_t size, size_t align) const 
+{
+    if (align < size) 
+        /// Will be automatically aligned if align is valid (as it will be power of 2 that less than size)
+        return calculateLevel(size);
+    else 
+        return calculateLevel(align);
+}
+
+size_t BuddyArena::calculateBlockSizeOnLevel(size_t level) const 
+{
+    return minimal_allocation_size_bytes * (1ull << ((number_of_levels - level) - 1));
+}
+
+size_t BuddyArena::calculateIndexInLevel(const MemoryBlock * block, size_t level) const 
+{
+    const auto * block_data = reinterpret_cast<const char *>(block);
+    const auto * arena_data = static_cast<const char *>(arena_buffer);
+    return (block_data - arena_data) / calculateBlockSizeOnLevel(level);
+}
+
+size_t BuddyArena::calculateIndex(const MemoryBlock * block, size_t level) const 
+{
+    return (1ull << level) + calculateIndexInLevel(block, level) - 1ull;
+}
+
+size_t BuddyArena::calculatePointerIndex(const MemoryBlock * block) const 
+{
+    const auto * block_data = reinterpret_cast<const char *>(block);
+    const auto * arena_data = static_cast<const char *>(arena_buffer);
+        
+    return (block_data - arena_data) / calculateBlockSizeOnLevel(number_of_levels - 1);
+}
+
+size_t BuddyArena::calculateMinBlocksNumber(size_t size_bytes) const
+{
+    return size_bytes / minimal_allocation_size_bytes + (size_bytes % minimal_allocation_size_bytes == 0 ? 0 : 1);
+}
+
+BuddyArena::MemoryBlock * BuddyArena::blockFromIndexInLevel(size_t index_in_level, size_t level) const
+{
+    auto block_size = calculateBlockSizeOnLevel(level); 
+    return reinterpret_cast<MemoryBlock *>(static_cast<char *>(arena_buffer) + block_size * index_in_level);
+}
+
+size_t BuddyArena::getPointerLevel(const MemoryBlock * block) const 
+{
+    const auto pointer_index = calculatePointerIndex(block);
+    return pointers_levels[pointer_index];
+}
+
+void BuddyArena::setPointerLevel(const MemoryBlock * block, size_t level) 
+{
+    const auto pointer_index = calculatePointerIndex(block);
+    pointers_levels[pointer_index] = level;
+}
+
+BuddyArena::MemoryBlock * BuddyArena::allocateBlock(size_t level) 
+{
+    // Found free block in the list
+    if (!isFreeListEmpty(level))
+    {
+        auto * free_block = free_lists[level];
+        removeFromFreeList(free_block, level);
+        return free_block;
+    }
+
+    // There are no free blocks on this level, allocate one from the top
+
+    // Already on the top
+    if (level == 0) 
+        throw std::bad_alloc();
+
+    auto * bigger_block = allocateBlock(level - 1);
+    auto [block, buddy_block] = divideBlock(bigger_block, level - 1);
+    addToFreeList(buddy_block, level);
+
+    return block;
+}
+
+void BuddyArena::deallocateBlock(MemoryBlock * block, size_t level) 
+{
+    assert(block);
+
+    auto * buddy = getBuddy(block, level);
+
+    if (buddy && getBlockStatus(buddy, level)) 
+    {
+        // Merge with buddy
+        auto * merged_block = mergeWithBuddy(block, buddy);
+        removeFromFreeList(buddy, level);
+        deallocateBlock(merged_block, level - 1);
+    } else 
+    {
+        addToFreeList(block, level);
+    }  
+}
+
+char * BuddyArena::initializeMetaStorage() 
+{
+    // Calculate sizes
+    size_t block_status_size = (1ull << number_of_levels) - 1ull;
+    size_t block_status_size_bytes = sizeof(bool) * block_status_size;
+    size_t block_status_size_minimal_blocks = calculateMinBlocksNumber(block_status_size_bytes);
+
+    size_t free_lists_size_bytes = sizeof(MemoryBlock *) * number_of_levels;
+    size_t free_lists_size_minimal_blocks = calculateMinBlocksNumber(free_lists_size_bytes);
+
+    size_t pointers_levels_size = (1ull << (number_of_levels - 1));
+    size_t pointers_levels_size_bytes = sizeof(uint8_t) * pointers_levels_size;
+    size_t pointers_levels_size_minmal_blocks = calculateMinBlocksNumber(pointers_levels_size_bytes);
+        
+    // Populate pointers 
+    auto * current_storage_ptr = reinterpret_cast<char *>(arena_buffer);
+
+    block_status = reinterpret_cast<bool *>(current_storage_ptr);
+    current_storage_ptr += block_status_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    free_lists = reinterpret_cast<MemoryBlock **>(current_storage_ptr);
+    current_storage_ptr += free_lists_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    pointers_levels = reinterpret_cast<uint8_t *>(current_storage_ptr);
+    current_storage_ptr += pointers_levels_size_minmal_blocks * minimal_allocation_size_bytes;
+
+    return current_storage_ptr;
+}
+
+std::pair<BuddyArena::MemoryBlock *, BuddyArena::MemoryBlock *> BuddyArena::divideBlock(
+    MemoryBlock * block, size_t level) 
+{
+    auto block_size = calculateBlockSizeOnLevel(level);
+
+    // TODO: Can be optimized
+    auto * block_data = reinterpret_cast<char *>(block);
+    auto * buddy_block_data = block_data + block_size / 2;
+
+    auto * memory_block = reinterpret_cast<MemoryBlock *>(block_data);
+    auto * buddy_memory_block = reinterpret_cast<MemoryBlock *>(buddy_block_data);
+
+    return {memory_block, buddy_memory_block};
+}
+
+BuddyArena::MemoryBlock * BuddyArena::mergeWithBuddy(MemoryBlock * block, MemoryBlock * buddy)
+{
+    assert(block);
+    assert(buddy);
+
+    auto * block_data = reinterpret_cast<char *>(block);
+    auto * buddy_block_data = reinterpret_cast<char *>(buddy);
+
+    if (block_data < buddy_block_data) 
+        return reinterpret_cast<MemoryBlock *>(block_data);
+    else 
+        return reinterpret_cast<MemoryBlock *>(buddy_block_data);
+}
+
+BuddyArena::MemoryBlock * BuddyArena::getBuddy(MemoryBlock * block, size_t level) const 
+{
+    auto index_in_level = calculateIndexInLevel(block, level);
+    size_t buddy_index_in_level = index_in_level % 2 == 0 ? index_in_level + 1 : index_in_level - 1;
+    return blockFromIndexInLevel(buddy_index_in_level, level);
+}
+
+bool BuddyArena::getBlockStatus(const MemoryBlock * block, size_t level) const
+{
+    auto index_of_block = calculateIndex(block, level);
+    return block_status[index_of_block];
+}
+
+void BuddyArena::setBlockStatus(const MemoryBlock * block, size_t level, bool status)
+{
+    auto index_of_block = calculateIndex(block, level);
+    block_status[index_of_block] = status; 
+}
+
+void BuddyArena::printMemoryUsageDummy() const 
+{
+    auto occupied_blocks = min_blocks_num - free_min_blocks;
+    double usage = static_cast<double>(occupied_blocks) / min_blocks_num * 100.0;
+    std::cout << "***Memory usage: " << occupied_blocks << " / " << min_blocks_num << " (" << std::fixed << std::setprecision(1) << usage << " %)***" << std::endl;
+}
+
+void BuddyArena::addToFreeList(MemoryBlock * block, size_t level) 
+{
+    setBlockStatus(block, level, true);
+
+    auto & free_list = free_lists[level];
+
+    if (free_list) 
+    {
+        block->pointers.next = free_list;
+        block->pointers.previous = nullptr;
+        free_list->pointers.previous = block;
+    } else 
+    {
+        block->pointers.next = nullptr;
+        block->pointers.previous = nullptr;
+    }
+
+    free_list = block;
+}
+
+bool BuddyArena::isFreeListEmpty(size_t level) const 
+{
+    return free_lists[level] == nullptr;
+}
+
+void BuddyArena::removeFromFreeList(MemoryBlock * block, size_t level) 
+{
+    assert(!isFreeListEmpty(level));
+
+    setBlockStatus(block, level, false);
+
+    if (block->pointers.next) 
+        block->pointers.next->pointers.previous = block->pointers.previous;
+
+    if (block->pointers.previous) 
+        block->pointers.previous->pointers.next = block->pointers.next;
+
+    /// Move the end of the list if we delete it
+    if (block == free_lists[level]) 
+        free_lists[level] = block->pointers.next;
+
+    block->pointers.next = nullptr;
+    block->pointers.previous = nullptr;
+}
+
+void * BuddyAllocator::alloc(size_t size, size_t alignment)
+{
+    checkSize(size);
+    CurrentMemoryTracker::allocNoThrow(size);
+    return allocNoTrack(size, alignment);
+}
+
+void BuddyAllocator::free(void * buf, size_t size)
+{
+    try
+    {
+        checkSize(size);
+        freeNoTrack(buf, size);
+        CurrentMemoryTracker::free(size);
+    }
+    catch (...)
+    {
+        DB::tryLogCurrentException("BuddyAllocator::free");
+        throw;
+    }
+}
+
+void * BuddyAllocator::realloc(void * buf, size_t old_size, size_t new_size, size_t alignment)
+{
+    checkSize(new_size);
+
+    if (old_size == new_size)
+    {
+        /// nothing to do.
+        /// BTW, it's not possible to change alignment while doing realloc.
+    }
+    else
+    {
+        /// Big allocs that requires a copy. MemoryTracker is called inside 'alloc', 'free' methods.
+
+        void * new_buf = alloc(new_size, alignment);
+        memcpy(new_buf, buf, std::min(old_size, new_size));
+        free(buf, old_size);
+        buf = new_buf;
+    }
+
+    // LOG_INFO(&Poco::Logger::get("UnifiedCache"), "BuddyAllocator: Reallocate buffer {} with old size {} and new size {} (do realloc)", buf, ReadableSize(old_size), ReadableSize(new_size));
+
+    return buf;
+}
+
+void BuddyAllocator::checkSize(size_t size)
+{
+    /// More obvious exception in case of possible overflow (instead of just "Cannot mmap").
+    if (size >= 0x8000000000000000ULL)
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Too large size ({}) passed to allocator. It indicates an error.", size);
+}
+
+void * BuddyAllocator::allocNoTrack(size_t size, size_t alignment) 
+{
+    auto & instance = BuddyArena::instance();
+    void * buf = nullptr;
+
+    if (size >= DB::UNIFIED_ALLOC_THRESHOLD && instance.isValid())
+    {
+        buf = instance.malloc(size, alignment);
+
+        if (nullptr == buf)
+            DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot allocate memory (BuddyArena) {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+        if constexpr (clear_memory)
+            memset(buf, 0, size);
+    }
+    /// TODO: Remove hardcoded constant, only for temporary tests of base Allocator replacement
+    // else if (alignment <= MALLOC_MIN_ALIGNMENT)
+    else if (alignment <= 8)
+    {
+        if constexpr (clear_memory)
+            buf = ::calloc(size, 1);
+        else
+            buf = ::malloc(size);
+
+        if (nullptr == buf)
+            DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot malloc {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+    }
+    else
+    {
+        buf = nullptr;
+        int res = posix_memalign(&buf, alignment, size);
+
+        if (0 != res)
+            DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot allocate memory (posix_memalign) {}.", ReadableSize(size)),
+                DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, res);
+
+        if constexpr (clear_memory)
+            memset(buf, 0, size);
+    }
+
+    return buf;
+}
+
+void BuddyAllocator::freeNoTrack(void * buf, size_t /*size*/)
+{
+    if (nullptr == buf) {
+        return;
+    }
+
+    auto & instance = BuddyArena::instance();
+    if (instance.isValid() && instance.isAllocated(buf)) 
+        instance.free(buf);
+    else
+        ::free(buf);
+}
+
+}

--- a/src/Common/UnifiedCache.h
+++ b/src/Common/UnifiedCache.h
@@ -91,12 +91,11 @@ private:
     std::atomic<size_t> free_min_blocks = 0;
     size_t min_blocks_num = 0;
 
-    std::mutex mutex;
-
     /// Meta storage 
     bool * block_status;
     uint8_t * pointers_levels;
     MemoryBlock ** free_lists;
+    std::mutex * mutexes;
 
     [[nodiscard]] static void * allocateArena(size_t size); 
     static void deallocateArena(void * buffer, size_t size);

--- a/src/Common/UnifiedCache.h
+++ b/src/Common/UnifiedCache.h
@@ -171,7 +171,7 @@ public:
             printMemoryUsageDummy();
         }
 
-        CurrentMemoryTracker::alloc(size);
+        // CurrentMemoryTracker::alloc(size);
 
         return block->data;
     }
@@ -192,7 +192,7 @@ public:
         if (free_min_blocks % 10000 == 0) {
             printMemoryUsageDummy();
         }
-        CurrentMemoryTracker::free(freeing_memory);
+        // CurrentMemoryTracker::free(freeing_memory);
     }
 
     void free(void * buf) noexcept
@@ -209,7 +209,7 @@ public:
         if (free_min_blocks % 10000 == 0) {
             printMemoryUsageDummy();
         }
-        CurrentMemoryTracker::free(freeing_memory);
+        // CurrentMemoryTracker::free(freeing_memory);
     }
 
     [[nodiscard]] double getFreeSpaceRatio() const
@@ -252,7 +252,7 @@ private:
         /// TODO: Remove temporary hack to make the memory tracker works
         /// As we allocated the memory arena, we don't want to take it into account in the 
         /// memory tracker
-        CurrentMemoryTracker::free(size);
+        // CurrentMemoryTracker::free(size);
 
         return buffer;
     }

--- a/src/Common/UnifiedCache.h
+++ b/src/Common/UnifiedCache.h
@@ -25,6 +25,8 @@
 namespace DB 
 {
 
+extern const size_t UNIFIED_ALLOC_THRESHOLD;
+
 namespace ErrorCodes
 {
     extern const int CANNOT_ALLOCATE_MEMORY;
@@ -51,176 +53,32 @@ public:
     };
 
     static BuddyArena & instance()
-     {
+    {
         static BuddyArena arena;
         return arena;    
     }
 
     BuddyArena() = default;
 
-    ~BuddyArena() noexcept
-    {
-        if (isValid())
-            // Do not throw exceptions from invalid munmap
-            munmap(arena_buffer, total_size_bytes);
-    }
+    ~BuddyArena() noexcept;
 
     BuddyArena(const BuddyArena&) = delete;
     BuddyArena(BuddyArena&&) = delete;
     BuddyArena& operator=(const BuddyArena&) = delete;
     BuddyArena& operator=(BuddyArena&&) = delete;
 
-    bool isValid() const 
-    {
-        return number_of_levels != 0;
-    }
+    bool isValid() const;
 
     /// Check that the ptr is contained in the allocated memory arena
-    bool isAllocated(const void * ptr) const 
-    {
-        const auto * arena_end = reinterpret_cast<char *>(arena_buffer) + total_size_bytes;
-        return ptr >= arena_buffer && ptr < reinterpret_cast<const void *>(arena_end); 
-    }
+    bool isAllocated(const void * ptr) const;
 
-    void initialize(size_t minimal_allocation_size, size_t size)
-    {
-        /// We will divide the whole size bytes on blocks with size == minimal_allocation_size
-        assert(size % minimal_allocation_size == 0);
+    void initialize(size_t minimal_allocation_size, size_t size);
 
-        total_size_bytes = size;
-        number_of_levels = 1;
-        minimal_allocation_size_bytes = minimal_allocation_size;
+    void * malloc(size_t size, size_t align = 0);
+    void free(void * buf) noexcept;
 
-        /// Calculate number of levels
-        size_t number_of_blocks_on_level = size / minimal_allocation_size; 
-
-        /// Number of blocks on the level could not be the power of 2
-        /// In this case we intentionally add one level to the binary tree so we'll have enough 
-        /// leaves to store all minimal blocks
-        if (number_of_blocks_on_level > 1 && number_of_blocks_on_level % 2 != 0) 
-            ++number_of_levels;
-
-        while (number_of_blocks_on_level > 1) 
-        {
-            number_of_blocks_on_level >>= 1;
-            ++number_of_levels;
-        }
-
-        /// Calculate number of minimal blocks in the memory arena
-        min_blocks_num = (1ull << (number_of_levels - 1));
-        free_min_blocks = min_blocks_num;
-
-        arena_buffer = allocateArena(total_size_bytes);
-
-        auto * current_storage_ptr = initializeMetaStorage();
-
-
-        // TODO: Optimize
-        /// Initialize free_lists
-
-        /// Calculate number of blocks for the meta storage
-        size_t meta_storage_size_minimal_blocks = (current_storage_ptr - reinterpret_cast<char *>(arena_buffer)) / minimal_allocation_size_bytes;
-
-        /// Calculate the nearest power of 2 that is greater than meta storage size
-        size_t meta_storage_size_round_up_to_power_of_2 = 1;
-        while (meta_storage_size_round_up_to_power_of_2 < meta_storage_size_minimal_blocks) 
-        {
-            meta_storage_size_round_up_to_power_of_2 *= 2;
-        }
-
-        /// Deallocate minimal blocks to fill the space between the meta storage and the size that is
-        /// the nearest power of 2, so after it we can deallocate blocks with an exponential increasing sizes 
-        /// Arena buffer:
-        /// [*******-------------|------------------------------------]
-        ///  |               |   |
-        ///  ^ meta storage  |   ^ meta_storage_size_round_up_to_power_of_2
-        ///                  ^ deallocate these blocks on this step
-        const auto * minimal_blocks_area_end = reinterpret_cast<char *>(arena_buffer) + meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size_bytes;
-        while (current_storage_ptr != minimal_blocks_area_end) 
-        {
-            deallocateBlock(reinterpret_cast<MemoryBlock *>(current_storage_ptr), number_of_levels - 1);
-            current_storage_ptr += minimal_allocation_size_bytes;
-        }
-
-        /// Deallocate all next blocks after meta_storage_size_round_up_to_power_of_2 with increasing sizes 
-        size_t current_block_size_bytes = meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size;
-        size_t current_block_level = calculateLevel(current_block_size_bytes);
-        while (current_block_level > 0) 
-        {
-            deallocateBlock(reinterpret_cast<MemoryBlock *>(current_storage_ptr), current_block_level);
-            current_storage_ptr += current_block_size_bytes;
-            current_block_size_bytes *= 2;
-            --current_block_level;
-        }
-    }
-
-    void * malloc(size_t size, size_t align = 0) 
-    {
-        /// TODO: Add assertion
-        /// assert that align is a power of 2 and a multiple of sizeof(void*) 
-        /// https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
-
-        auto level = calculateLevel(size, align);
-
-        std::lock_guard lock(mutex);
-        auto * block = allocateBlock(level);
-        setPointerLevel(block, level);
-
-        /// TODO: Remove temp local dummy memory tracker
-        const size_t allocated_memory_blocks = 1ull << ((number_of_levels - level) - 1);
-        free_min_blocks.fetch_sub(allocated_memory_blocks);
-        // if (free_min_blocks % 10000 == 0) {
-        //     printMemoryUsageDummy();
-        // }
-
-        return block->data;
-    }
-
-    /// TODO: Probably remove this function, code duplication
-    /// This function could be implemented faster than free(void *) but the optimization can be minor
-    void free(void * buf, size_t size) noexcept
-    {
-        auto * block = reinterpret_cast<MemoryBlock *>(buf);
-        auto level = calculateLevel(size);
-
-        std::lock_guard lock(mutex);
-        deallocateBlock(block, level);
-
-        /// TODO: Remove temp local dummy memory tracker
-        const size_t freeing_memory_blocks = 1ull << ((number_of_levels - level) - 1);
-        free_min_blocks.fetch_add(freeing_memory_blocks);
-        // if (free_min_blocks % 10000 == 0) {
-        //     printMemoryUsageDummy();
-        // }
-    }
-
-    void free(void * buf) noexcept
-    {
-        auto * block = reinterpret_cast<MemoryBlock *>(buf);
-        auto level = getPointerLevel(block);
-
-        std::lock_guard lock(mutex);
-        deallocateBlock(block, level);
-
-        /// TODO: Remove temp local dummy memory tracker
-        const size_t freeing_memory_blocks = 1ull << ((number_of_levels - level) - 1);
-        free_min_blocks.fetch_add(freeing_memory_blocks);
-        // if (free_min_blocks % 10000 == 0) {
-        //     printMemoryUsageDummy();
-        // }
-    }
-
-    [[nodiscard]] double getFreeSpaceRatio() const
-    {
-        /// TODO: Change seq_cst memory_order on the free_min_blocks atomic
-        auto occupied_blocks = min_blocks_num - free_min_blocks.load();
-        return static_cast<double>(min_blocks_num - occupied_blocks) / min_blocks_num;
-    }
-
-    [[nodiscard]] size_t getTotalSizeBytes() const
-    {
-        return total_size_bytes;
-    }
+    [[nodiscard]] double getFreeSpaceRatio() const;
+    [[nodiscard]] size_t getTotalSizeBytes() const;
 
 private:
     void * arena_buffer;
@@ -240,275 +98,44 @@ private:
     uint8_t * pointers_levels;
     MemoryBlock ** free_lists;
 
-    [[nodiscard]] static void * allocateArena(size_t size) 
-    {
-        void * buffer = mmap(nullptr, size, PROT_READ | PROT_WRITE, 
-                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, /*fd=*/ -1, /*offset=*/ 0);
-        if (MAP_FAILED == buffer)
-            DB::throwFromErrno(fmt::format("BuddyArena: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+    [[nodiscard]] static void * allocateArena(size_t size); 
+    static void deallocateArena(void * buffer, size_t size);
 
-        /// TODO: Remove temporary hack to make the memory tracker works
-        /// As we allocated the memory arena, we don't want to take it into account in the 
-        /// memory tracker
-        // CurrentMemoryTracker::free(size);
-
-        return buffer;
-    }
-
-    static void deallocateArena(void * buffer, size_t size) 
-    {
-        munmap(buffer, size);
-    }
-
-    size_t calculateLevel(size_t size) const 
-    {
-        // TODO: optimize
-        size_t current_level = number_of_levels - 1;
-        size_t current_block_size = calculateBlockSizeOnLevel(current_level);
-
-        while (size > current_block_size) 
-        {
-            // Low in memory
-            if (current_level == 0) 
-                DB::throwFromErrno(fmt::format("BuddyArena: Cannot find level for size {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-
-            --current_level;
-            current_block_size *= 2;
-        }
-
-        return current_level;
-    }
-
-    size_t calculateLevel(size_t size, size_t align) const 
-    {
-        if (align < size) 
-            /// Will be automatically aligned if align is valid (as it will be power of 2 that less than size)
-            return calculateLevel(size);
-        else 
-            return calculateLevel(align);
-    }
-
-    size_t calculateBlockSizeOnLevel(size_t level) const 
-    {
-        return minimal_allocation_size_bytes * (1ull << ((number_of_levels - level) - 1));
-    }
-
-    size_t calculateIndexInLevel(const MemoryBlock * block, size_t level) const 
-    {
-        const auto * block_data = reinterpret_cast<const char *>(block);
-        const auto * arena_data = static_cast<const char *>(arena_buffer);
-        return (block_data - arena_data) / calculateBlockSizeOnLevel(level);
-    }
-
-    size_t calculateIndex(const MemoryBlock * block, size_t level) const 
-    {
-        return (1ull << level) + calculateIndexInLevel(block, level) - 1ull;
-    }
-
-    size_t calculatePointerIndex(const MemoryBlock * block) const 
-    {
-        const auto * block_data = reinterpret_cast<const char *>(block);
-        const auto * arena_data = static_cast<const char *>(arena_buffer);
-        
-        return (block_data - arena_data) / calculateBlockSizeOnLevel(number_of_levels - 1);
-    }
-
-    MemoryBlock * blockFromIndexInLevel(size_t index_in_level, size_t level) const 
-    {
-        auto block_size = calculateBlockSizeOnLevel(level); 
-        return reinterpret_cast<MemoryBlock *>(static_cast<char *>(arena_buffer) + block_size * index_in_level);
-    }
+    size_t calculateLevel(size_t size) const; 
+    size_t calculateLevel(size_t size, size_t align) const;
+    size_t calculateBlockSizeOnLevel(size_t level) const;
+    size_t calculateIndexInLevel(const MemoryBlock * block, size_t level) const; 
+    size_t calculateIndex(const MemoryBlock * block, size_t level) const; 
+    size_t calculatePointerIndex(const MemoryBlock * block) const;
 
     /// Calculate number of minimal blocks for the allocation on the lower level
     /// Used to calculate offset for the meta storage beforehand
-    size_t calculateMinBlocksNumber(size_t size_bytes) const
-    {
-        return size_bytes / minimal_allocation_size_bytes + (size_bytes % minimal_allocation_size_bytes == 0 ? 0 : 1);
-    }
+    size_t calculateMinBlocksNumber(size_t size_bytes) const;
 
-    size_t getPointerLevel(const MemoryBlock * block) const 
-    {
-        const auto pointer_index = calculatePointerIndex(block);
-        return pointers_levels[pointer_index];
-    }
+    MemoryBlock * blockFromIndexInLevel(size_t index_in_level, size_t level) const;
 
-    void setPointerLevel(const MemoryBlock * block, size_t level) 
-    {
-        const auto pointer_index = calculatePointerIndex(block);
-        pointers_levels[pointer_index] = level;
-    }
+    size_t getPointerLevel(const MemoryBlock * block) const;
+    void setPointerLevel(const MemoryBlock * block, size_t level); 
 
-    MemoryBlock * allocateBlock(size_t level) 
-    {
-        // Found free block in the list
-        if (!isFreeListEmpty(level))
-        {
-            auto * free_block = free_lists[level];
-            removeFromFreeList(free_block, level);
-            return free_block;
-        }
+    MemoryBlock * allocateBlock(size_t level); 
+    void deallocateBlock(MemoryBlock * block, size_t level); 
 
-        // There are no free blocks on this level, allocate one from the top
+    char * initializeMetaStorage(); 
 
-        // Already on the top
-        if (level == 0) 
-            throw std::bad_alloc();
+    std::pair<MemoryBlock *, MemoryBlock *> divideBlock(MemoryBlock * block, size_t level); 
+    static MemoryBlock * mergeWithBuddy(MemoryBlock * block, MemoryBlock * buddy);
+    MemoryBlock * getBuddy(MemoryBlock * block, size_t level) const; 
 
-        auto * bigger_block = allocateBlock(level - 1);
-        auto [block, buddy_block] = divideBlock(bigger_block, level - 1);
-        addToFreeList(buddy_block, level);
-
-        return block;
-    }
-
-    char * initializeMetaStorage() 
-    {
-        // Calculate sizes
-        size_t block_status_size = (1ull << number_of_levels) - 1ull;
-        size_t block_status_size_bytes = sizeof(bool) * block_status_size;
-        size_t block_status_size_minimal_blocks = calculateMinBlocksNumber(block_status_size_bytes);
-
-        size_t free_lists_size_bytes = sizeof(MemoryBlock *) * number_of_levels;
-        size_t free_lists_size_minimal_blocks = calculateMinBlocksNumber(free_lists_size_bytes);
-
-        size_t pointers_levels_size = (1ull << (number_of_levels - 1));
-        size_t pointers_levels_size_bytes = sizeof(uint8_t) * pointers_levels_size;
-        size_t pointers_levels_size_minmal_blocks = calculateMinBlocksNumber(pointers_levels_size_bytes);
-        
-        // Populate pointers 
-        auto * current_storage_ptr = reinterpret_cast<char *>(arena_buffer);
-
-        block_status = reinterpret_cast<bool *>(current_storage_ptr);
-        current_storage_ptr += block_status_size_minimal_blocks * minimal_allocation_size_bytes;
-
-        free_lists = reinterpret_cast<MemoryBlock **>(current_storage_ptr);
-        current_storage_ptr += free_lists_size_minimal_blocks * minimal_allocation_size_bytes;
-
-        pointers_levels = reinterpret_cast<uint8_t *>(current_storage_ptr);
-        current_storage_ptr += pointers_levels_size_minmal_blocks * minimal_allocation_size_bytes;
-
-        return current_storage_ptr;
-    }
-
-    void deallocateBlock(MemoryBlock * block, size_t level) 
-    {
-        assert(block);
-
-        auto * buddy = getBuddy(block, level);
-
-        if (buddy && getBlockStatus(buddy, level)) 
-        {
-            // Merge with buddy
-            auto * merged_block = mergeWithBuddy(block, buddy);
-            removeFromFreeList(buddy, level);
-            deallocateBlock(merged_block, level - 1);
-        } else 
-        {
-            addToFreeList(block, level);
-        }  
-    }
-
-    std::pair<MemoryBlock *, MemoryBlock *> divideBlock(
-        MemoryBlock * block, size_t level) 
-    {
-        auto block_size = calculateBlockSizeOnLevel(level);
-
-        // TODO: Can be optimized
-        auto * block_data = reinterpret_cast<char *>(block);
-        auto * buddy_block_data = block_data + block_size / 2;
-
-        auto * memory_block = reinterpret_cast<MemoryBlock *>(block_data);
-        auto * buddy_memory_block = reinterpret_cast<MemoryBlock *>(buddy_block_data);
-
-        return {memory_block, buddy_memory_block};
-    }
-
-    static MemoryBlock * mergeWithBuddy(MemoryBlock * block, MemoryBlock * buddy)
-    {
-        assert(block);
-        assert(buddy);
-
-        auto * block_data = reinterpret_cast<char *>(block);
-        auto * buddy_block_data = reinterpret_cast<char *>(buddy);
-
-        if (block_data < buddy_block_data) 
-            return reinterpret_cast<MemoryBlock *>(block_data);
-        else 
-            return reinterpret_cast<MemoryBlock *>(buddy_block_data);
-    }
-
-    MemoryBlock * getBuddy(MemoryBlock * block, size_t level) const 
-    {
-        auto index_in_level = calculateIndexInLevel(block, level);
-        size_t buddy_index_in_level = index_in_level % 2 == 0 ? index_in_level + 1 : index_in_level - 1;
-        return blockFromIndexInLevel(buddy_index_in_level, level);
-    }
-
-    bool getBlockStatus(const MemoryBlock * block, size_t level)
-    {
-        auto index_of_block = calculateIndex(block, level);
-        return block_status[index_of_block];
-    }
-
-    void setBlockStatus(const MemoryBlock * block, size_t level, bool status)
-    {
-        auto index_of_block = calculateIndex(block, level);
-        block_status[index_of_block] = status; 
-    }
+    bool getBlockStatus(const MemoryBlock * block, size_t level) const;
+    void setBlockStatus(const MemoryBlock * block, size_t level, bool status);
 
     /// TODO: Remove this method
     /// Temporarly use only
-    void printMemoryUsageDummy() const 
-    {
-        auto occupied_blocks = min_blocks_num - free_min_blocks;
-        double usage = static_cast<double>(occupied_blocks) / min_blocks_num * 100.0;
-        std::cout << "***Memory usage: " << occupied_blocks << " / " << min_blocks_num << " (" << std::fixed << std::setprecision(1) << usage << " %)***" << std::endl;
-    }
+    void printMemoryUsageDummy() const; 
 
-    void addToFreeList(MemoryBlock * block, size_t level) 
-    {
-        setBlockStatus(block, level, true);
-
-        auto & free_list = free_lists[level];
-
-        if (free_list) 
-        {
-            block->pointers.next = free_list;
-            block->pointers.previous = nullptr;
-            free_list->pointers.previous = block;
-        } else 
-        {
-            block->pointers.next = nullptr;
-            block->pointers.previous = nullptr;
-        }
-
-        free_list = block;
-    }
-
-    bool isFreeListEmpty(size_t level) const 
-    {
-        return free_lists[level] == nullptr;
-    }
-
-    void removeFromFreeList(MemoryBlock * block, size_t level) 
-    {
-        assert(!isFreeListEmpty(level));
-
-        setBlockStatus(block, level, false);
-
-        if (block->pointers.next) 
-            block->pointers.next->pointers.previous = block->pointers.previous;
-
-        if (block->pointers.previous) 
-            block->pointers.previous->pointers.next = block->pointers.next;
-
-        /// Move the end of the list if we delete it
-        if (block == free_lists[level]) 
-            free_lists[level] = block->pointers.next;
-
-        block->pointers.next = nullptr;
-        block->pointers.previous = nullptr;
-    }
+    void addToFreeList(MemoryBlock * block, size_t level);
+    bool isFreeListEmpty(size_t level) const; 
+    void removeFromFreeList(MemoryBlock * block, size_t level);
 };
 
 template <typename TKey, typename HashFunction = std::hash<TKey>>
@@ -533,7 +160,7 @@ public:
 
     void initialize(size_t max_size_, 
                     double free_ram_ratio_to_start_cache_eviction_, 
-                    double ram_ratio_for_cache_eviciton_amount_) 
+                    double ram_ratio_for_cache_eviciton_amount_)
     {
         max_size = max_size_;
         free_ram_ratio_to_start_cache_eviction = free_ram_ratio_to_start_cache_eviction_;
@@ -541,12 +168,12 @@ public:
         is_cache_evictions_on_low_memory_enabled = true;
     }
 
-    [[nodiscard]] bool isValid() const
+    [[nodiscard]] bool isValid() const 
     {
         return max_size > 0;
     }
 
-    [[nodiscard]] size_t getCacheWeight() const 
+    [[nodiscard]] size_t getCacheWeight() const
     {
         std::lock_guard lock(mutex);
         return current_size;
@@ -572,8 +199,14 @@ public:
         return current_count_by_types[typeid(TMapped)];
     }
 
+    void remove(const Key & key, std::lock_guard<std::mutex> & /*cache_lock*/)
+    {
+        std::lock_guard lock(mutex);
+        removeLocked(key);
+    }
+
     template <typename TMapped> 
-    std::shared_ptr<TMapped> get(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) 
+    std::shared_ptr<TMapped> get(const Key & key, std::lock_guard<std::mutex> & /*cache_lock*/)
     {
         std::lock_guard lock(mutex);
 
@@ -591,15 +224,9 @@ public:
         return std::static_pointer_cast<TMapped>(cell.value);
     }
 
-    void remove(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */)
-    {
-        std::lock_guard lock(mutex);
-        removeLocked(key);
-    }
-
     /// Similar to the remove function but performs deletions for all keys corresponding to the given type TMapped
     template <typename TMapped>
-    void reset(std::lock_guard<std::mutex> & /* cache_lock */) 
+    void reset(std::lock_guard<std::mutex> & /*cache_lock*/)
     {
         std::lock_guard lock(mutex);
 
@@ -618,10 +245,10 @@ public:
     }
 
     template <typename TMapped>
-    void set(const Key & key, const std::shared_ptr<TMapped> & mapped, size_t weight, std::lock_guard<std::mutex> & /* cache_lock */)
+    void set(const Key & key, const std::shared_ptr<TMapped> & mapped, size_t weight, std::lock_guard<std::mutex> & /*cache_lock*/)
     {
         std::lock_guard lock(mutex);
-        
+    
         auto [it, inserted] = cells.emplace(std::piecewise_construct,
             std::forward_as_tuple(key),
             std::forward_as_tuple(typeid(TMapped)));
@@ -663,6 +290,7 @@ public:
         std::lock_guard lock(mutex);
         return removeWeightLocked(weight);
     }
+
 private:
     using LRUQueue = std::list<Key>;
     using LRUQueueIterator = typename LRUQueue::iterator;
@@ -729,7 +357,7 @@ private:
         }
     }
 
-    size_t removeWeightLocked(size_t weight) 
+    size_t removeWeightLocked(size_t weight)
     {
         LOG_DEBUG(&Poco::Logger::get("UnifiedCache"), "LRUUnifiedCacheGlobal: remove weight {}", ReadableSize(weight));
 
@@ -759,7 +387,6 @@ private:
         return current_weight_lost;
     }
 };
-
 
 /// Proxy-class - redirects all calls to the corresponding methods of the LRUUnifiedCacheGlobal global instance
 template <typename TKey, typename TMapped, typename HashFunction = std::hash<TKey>, typename WeightFunction = TrivialWeightFunction<TMapped>>
@@ -836,61 +463,20 @@ protected:
     GlobalCachePolicy & instance;
 };
 
-
 class BuddyAllocator
 {
 public:
     /// Allocate memory range.
-    static void * alloc(size_t size, size_t alignment = 0)
-    {
-        checkSize(size);
-        // CurrentMemoryTracker::alloc(size);
-        return allocNoTrack(size, alignment);
-    }
+    static void * alloc(size_t size, size_t alignment = 0);
 
     /// Free memory range.
-    static void free(void * buf, size_t size)
-    {
-        try
-        {
-            checkSize(size);
-            freeNoTrack(buf, size);
-            // CurrentMemoryTracker::free(size);
-        }
-        catch (...)
-        {
-            DB::tryLogCurrentException("BuddyAllocator::free");
-            throw;
-        }
-    }
+    static void free(void * buf, size_t size);
 
     /** Enlarge memory range.
       * Data from old range is moved to the beginning of new range.
       * Address of memory range could change.
       */
-    static void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0)
-    {
-        checkSize(new_size);
-
-        if (old_size == new_size)
-        {
-            /// nothing to do.
-            /// BTW, it's not possible to change alignment while doing realloc.
-        }
-        else
-        {
-            /// Big allocs that requires a copy. MemoryTracker is called inside 'alloc', 'free' methods.
-
-            void * new_buf = alloc(new_size, alignment);
-            memcpy(new_buf, buf, std::min(old_size, new_size));
-            free(buf, old_size);
-            buf = new_buf;
-        }
-
-        // LOG_INFO(&Poco::Logger::get("UnifiedCache"), "BuddyAllocator: Reallocate buffer {} with old size {} and new size {} (do realloc)", buf, ReadableSize(old_size), ReadableSize(new_size));
-
-        return buf;
-    }
+    static void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0);
 
 protected:
     static constexpr size_t getStackThreshold()
@@ -901,67 +487,9 @@ protected:
     static constexpr bool clear_memory = true;
 
 private:
-    static void checkSize(size_t size)
-    {
-        /// More obvious exception in case of possible overflow (instead of just "Cannot mmap").
-        if (size >= 0x8000000000000000ULL)
-            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Too large size ({}) passed to allocator. It indicates an error.", size);
-    }
-
-    static void * allocNoTrack(size_t size, size_t alignment = 0) 
-    {
-        auto & instance = BuddyArena::instance();
-        void * buf = nullptr;
-        if (instance.isValid()) 
-        {
-            buf = instance.malloc(size, alignment);
-
-            if (nullptr == buf)
-                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot allocate memory (BuddyArena) {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-
-            if constexpr (clear_memory)
-                memset(buf, 0, size);
-        }
-        /// TODO: Remove hardcoded constant, only for temporary tests of base Allocator replacement
-        // else if (alignment <= MALLOC_MIN_ALIGNMENT)
-        else if (alignment <= 8)
-        {
-            if constexpr (clear_memory)
-                buf = ::calloc(size, 1);
-            else
-                buf = ::malloc(size);
-
-            if (nullptr == buf)
-                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot malloc {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-        }
-        else
-        {
-            buf = nullptr;
-            int res = posix_memalign(&buf, alignment, size);
-
-            if (0 != res)
-                DB::throwFromErrno(fmt::format("BuddyAllocator: Cannot allocate memory (posix_memalign) {}.", ReadableSize(size)),
-                    DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, res);
-
-            if constexpr (clear_memory)
-                memset(buf, 0, size);
-        }
-
-        return buf;
-    }
-
-    static void freeNoTrack(void * buf, size_t size)
-    {
-        if (nullptr == buf) {
-            return;
-        }
-
-        auto & instance = BuddyArena::instance();
-        if (instance.isValid() && instance.isAllocated(buf)) 
-            instance.free(buf, size);
-        else
-            ::free(buf);
-    }
+    static void checkSize(size_t size);
+    static void * allocNoTrack(size_t size, size_t alignment = 0);
+    static void freeNoTrack(void * buf, size_t size);
 };
 
 }

--- a/src/Common/UnifiedCache.h
+++ b/src/Common/UnifiedCache.h
@@ -160,17 +160,14 @@ public:
         /// assert that align is a power of 2 and a multiple of sizeof(void*) 
         /// https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
 
-
         auto level = calculateLevel(size, align);
-        const size_t allocated_memory_blocks = 1ull << ((number_of_levels - level) - 1);
-
-        // CurrentMemoryTracker::allocNoThrow(allocated_memory_blocks * minimal_allocation_size_bytes);
 
         std::lock_guard lock(mutex);
         auto * block = allocateBlock(level);
         setPointerLevel(block, level);
 
         /// TODO: Remove temp local dummy memory tracker
+        const size_t allocated_memory_blocks = 1ull << ((number_of_levels - level) - 1);
         free_min_blocks.fetch_sub(allocated_memory_blocks);
         // if (free_min_blocks % 10000 == 0) {
         //     printMemoryUsageDummy();
@@ -195,8 +192,6 @@ public:
         // if (free_min_blocks % 10000 == 0) {
         //     printMemoryUsageDummy();
         // }
-
-        // CurrentMemoryTracker::free(freeing_memory_blocks * minimal_allocation_size_bytes);
     }
 
     void free(void * buf) noexcept
@@ -213,8 +208,6 @@ public:
         // if (free_min_blocks % 10000 == 0) {
         //     printMemoryUsageDummy();
         // }
-
-        // CurrentMemoryTracker::free(freeing_memory_blocks * minimal_allocation_size_bytes);
     }
 
     [[nodiscard]] double getFreeSpaceRatio() const

--- a/src/Common/UnifiedCache.h
+++ b/src/Common/UnifiedCache.h
@@ -1,0 +1,811 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <list>
+#include <memory>
+#include <sys/mman.h>
+#include <Poco/Logger.h>
+#include <mutex>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+
+#include <Common/HashTable/Hash.h>
+#include <Common/ICachePolicy.h>
+#include <Common/CurrentMemoryTracker.h>
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+#include <Common/formatReadable.h>
+
+namespace DB 
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+    extern const int CANNOT_MUNMAP;
+}
+
+template <typename TKey, typename HashFunction = std::hash<TKey>>
+class LRUUnifiedCacheGlobal
+{
+public:
+    using Key = TKey;
+
+    static LRUUnifiedCacheGlobal & instance()
+    {
+        static LRUUnifiedCacheGlobal cache;
+        return cache;    
+    }
+
+    LRUUnifiedCacheGlobal() = default;
+
+    void initialize(size_t size)
+    {
+        max_size = size;
+    }
+
+    template <typename TMapped> 
+    std::shared_ptr<TMapped> get(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */) 
+    {
+        std::lock_guard lock(mutex);
+
+        auto it = cells.find(key);
+        if (it == cells.end())
+        {
+            return std::shared_ptr<TMapped>();
+        }
+
+        Cell & cell = it->second;
+
+        /// Move the key to the end of the queue. The iterator remains valid.
+        queue.splice(queue.end(), queue, cell.queue_iterator);
+
+        return std::static_pointer_cast<TMapped>(cell.value);
+    }
+
+    void remove(const Key & key, std::lock_guard<std::mutex> & /* cache_lock */)
+    {
+        std::lock_guard lock(mutex);
+        removeLocked(key);
+    }
+
+    /// Similar to the remove function but performs deletions for all keys corresponding to the given type TMapped
+    template <typename TMapped>
+    void reset(std::lock_guard<std::mutex> & /* cache_lock */) 
+    {
+        std::lock_guard lock(mutex);
+
+        const std::type_index type_to_reset(typeid(TMapped));
+
+        std::vector<Key> keys_to_delete;
+        for (const auto & entry : cells) 
+        {
+            const auto & cell = entry.second;
+            if (cell.type == type_to_reset)
+                keys_to_delete.push_back(entry.first);
+        }
+
+        for (const auto & key : keys_to_delete) 
+            removeLocked(key);
+    }
+
+    template <typename TMapped>
+    void set(const Key & key, const std::shared_ptr<TMapped> & mapped, size_t weight, std::lock_guard<std::mutex> & /* cache_lock */)
+    {
+        {
+            std::lock_guard lock(mutex);
+        
+            auto [it, inserted] = cells.emplace(std::piecewise_construct,
+                std::forward_as_tuple(key),
+                std::forward_as_tuple(typeid(TMapped)));
+
+            Cell & cell = it->second;
+
+            if (inserted)
+            {
+                try
+                {
+                    cell.queue_iterator = queue.insert(queue.end(), key);
+                }
+                catch (...)
+                {
+                    cells.erase(it);
+                    throw;
+                }
+            }
+            else
+            {
+                current_size -= cell.size;
+                queue.splice(queue.end(), queue, cell.queue_iterator);
+            }
+
+            cell.value = std::static_pointer_cast<void>(mapped);
+            cell.size = cell.value ? weight : 0;
+            current_size += cell.size;
+        }
+
+        removeOverflow();
+    }
+
+    /// Evict entries using LRU strategy with approximate size = weight
+    size_t removeWeight(size_t weight)
+    {
+        std::lock_guard lock(mutex);
+
+        size_t current_weight_lost = 0;
+        while (current_size > 0 && current_weight_lost < weight)
+        {
+            const Key & key = queue.front();
+
+            auto it = cells.find(key);
+            if (it == cells.end())
+            {
+                LOG_ERROR(&Poco::Logger::get("UnifiedCache"), "LRUUnifiedCacheGlobal became inconsistent. There must be a bug in it.");
+                abort();
+            }
+
+            const auto & cell = it->second;
+
+            current_size -= cell.size;
+            current_weight_lost += cell.size;
+
+            cells.erase(it);
+            queue.pop_front();
+        }
+
+        return current_weight_lost;
+    }
+private:
+    using LRUQueue = std::list<Key>;
+    using LRUQueueIterator = typename LRUQueue::iterator;
+
+    LRUQueue queue;
+
+    struct Cell
+    {
+        std::shared_ptr<void> value = nullptr;
+        size_t size = 0;
+        std::type_index type; // is used in the reset funciton
+        LRUQueueIterator queue_iterator{};
+
+        explicit Cell(const std::type_info & type_info) : type(type_info) 
+        {}
+    };
+
+    using Cells = std::unordered_map<Key, Cell, HashFunction>;
+
+    Cells cells;
+
+    /// Total weight of values.
+    size_t current_size = 0;
+    size_t max_size = 0;
+
+    std::mutex mutex;
+
+    void removeOverflow()
+    {
+        if (current_size > max_size) 
+            removeWeight(current_size - max_size);
+    }
+
+    /// Remove entries with given key from the cells hashmap
+    /// Require lock on the mutex before calling
+    void removeLocked(const Key & key)
+    {
+        auto it = cells.find(key);
+        if (it == cells.end())
+            return;
+        auto & cell = it->second;
+        current_size -= cell.size;
+        queue.erase(cell.queue_iterator);
+        cells.erase(it);
+    }
+};
+
+
+/// Proxy-class - redirects all calls to the corresponding methods of the LRUUnifiedCacheGlobal global instance
+template <typename TKey, typename TMapped, typename HashFunction = std::hash<TKey>, typename WeightFunction = TrivialWeightFunction<TMapped>>
+class LRUUnifiedCachePolicy : public ICachePolicy<TKey, TMapped, HashFunction, WeightFunction>
+{
+public:
+    using Key = TKey;
+    using Mapped = TMapped;
+    using MappedPtr = std::shared_ptr<Mapped>;
+
+    using Base = ICachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
+    using typename Base::OnWeightLossFunction;
+
+    using GlobalCachePolicy = LRUUnifiedCacheGlobal<TKey, HashFunction>;
+
+    /** Initialize LRUCachePolicy with max_size and max_elements_size.
+      * max_elements_size == 0 means no elements size restrictions.
+      */
+    explicit LRUUnifiedCachePolicy(size_t max_size_, size_t max_elements_size_ = 0, OnWeightLossFunction on_weight_loss_function_ = {})
+        : max_size(std::max(static_cast<size_t>(1), max_size_))
+        , max_elements_size(max_elements_size_)
+        , instance(GlobalCachePolicy::instance())
+    {
+        Base::on_weight_loss_function = on_weight_loss_function_;
+    }
+
+    size_t weight(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    {
+        return current_size;
+    }
+
+    size_t count(std::lock_guard<std::mutex> & /* cache_lock */) const override
+    {
+        return number_of_elements;
+    }
+
+    size_t maxSize() const override
+    {
+        return max_size;
+    }
+
+    void reset(std::lock_guard<std::mutex> & cache_lock) override
+    {
+        instance.template reset<Mapped>(cache_lock);
+    }
+
+    void remove(const Key & key, std::lock_guard<std::mutex> & cache_lock) override
+    {
+        instance.remove(key, cache_lock);
+    }
+
+    MappedPtr get(const Key & key, std::lock_guard<std::mutex> & cache_lock) override
+    {
+        return instance.template get<Mapped>(key, cache_lock);
+    }
+
+    void set(const Key & key, const MappedPtr & mapped, std::lock_guard<std::mutex> & cache_lock) override
+    {
+        size_t weight = weight_function(*mapped);
+        instance.template set<Mapped>(key, mapped, weight, cache_lock);
+    }
+
+protected:
+    // Total weight of values.
+    // Not used for now, as we have a simple global cache policy
+    size_t current_size = 0;
+    size_t number_of_elements = 0;
+
+    const size_t max_size;
+    const size_t max_elements_size;
+
+    WeightFunction weight_function;
+    GlobalCachePolicy & instance;
+};
+
+/// Global memory arena under buddy allocator schema
+class BuddyArena
+{
+public:
+    union MemoryBlock;
+
+    /// Node of double-linked list
+    struct FreeMemoryBlock 
+    {
+        MemoryBlock * previous;
+        MemoryBlock * next;
+    };
+
+    union MemoryBlock 
+    {
+        FreeMemoryBlock pointers;
+        char data[0];
+    };
+
+    static BuddyArena & instance()
+     {
+        static BuddyArena arena;
+        return arena;    
+    }
+
+    BuddyArena() = default;
+
+    ~BuddyArena() noexcept
+    {
+        deallocateArena(arena_buffer, total_size_bytes);
+    }
+
+    BuddyArena(const BuddyArena&) = delete;
+    BuddyArena(BuddyArena&&) = delete;
+    BuddyArena& operator=(const BuddyArena&) = delete;
+    BuddyArena& operator=(BuddyArena&&) = delete;
+
+    bool isValid() const 
+    {
+        return number_of_levels != 0;
+    }
+
+    /// Check that the ptr is contained in the allocated memory arena
+    bool containsPtr(const void * ptr) const 
+    {
+        const auto * arena_end = reinterpret_cast<char *>(arena_buffer) + total_size_bytes;
+        return ptr >= arena_buffer && ptr < reinterpret_cast<const void *>(arena_end); 
+    }
+
+    void initialize(size_t minimal_allocation_size, size_t size)
+    {
+        total_size_bytes = size;
+        number_of_levels = 1;
+        minimal_allocation_size_bytes = minimal_allocation_size;
+
+        /// Calculate number of levels
+        size_t number_of_blocks_on_level = size / minimal_allocation_size; 
+        while (number_of_blocks_on_level > 1) 
+        {
+            number_of_blocks_on_level >>= 1;
+            ++number_of_levels;
+        }
+
+        /// Calculate number of minimal blocks in the memory arena
+        min_blocks_num = (1ull << (number_of_levels - 1));
+        free_min_blocks = min_blocks_num;
+
+        arena_buffer = allocateArena(total_size_bytes);
+
+        auto * current_storage_ptr = initializeMetaStorage();
+
+
+        // TODO: Optimize
+        /// Initialize free_lists
+
+        /// Calculate number of blocks for the meta storage
+        size_t meta_storage_size_minimal_blocks = (current_storage_ptr - reinterpret_cast<char *>(arena_buffer)) / minimal_allocation_size_bytes;
+
+        /// Calculate the nearest power of 2 that is greater than meta storage size
+        size_t meta_storage_size_round_up_to_power_of_2 = 1;
+        while (meta_storage_size_round_up_to_power_of_2 < meta_storage_size_minimal_blocks) 
+        {
+            meta_storage_size_round_up_to_power_of_2 *= 2;
+        }
+
+        /// Deallocate minimal blocks to fill the space between the meta storage and the size that is
+        /// the nearest power of 2
+        const auto * minimal_blocks_area_end = reinterpret_cast<char *>(arena_buffer) + meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size_bytes;
+        while (current_storage_ptr != minimal_blocks_area_end) 
+        {
+            deallocateBlock(reinterpret_cast<MemoryBlock *>(current_storage_ptr), number_of_levels - 1);
+            current_storage_ptr += minimal_allocation_size_bytes;
+        }
+
+        /// Deallocate next blocks with increasing sizes
+        size_t current_block_size_bytes = meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size;
+        size_t current_block_level = calculateLevel(current_block_size_bytes);
+        while (current_block_level > 0) 
+        {
+            deallocateBlock(reinterpret_cast<MemoryBlock *>(current_storage_ptr), current_block_level);
+            current_storage_ptr += current_block_size_bytes;
+            current_block_size_bytes *= 2;
+            --current_block_level;
+        }
+    }
+
+    void * allocate(size_t size)
+    {
+        auto level = calculateLevel(size);
+
+        std::lock_guard lock(mutex);
+        auto * block = allocateBlock(level);
+        setPointerLevel(block, level);
+
+        /// TODO: Remove temp local dummy memory tracker
+        free_min_blocks -= (1ull << ((number_of_levels - level) - 1));
+
+        return block->data;
+    }
+
+    void * allocate(size_t size, size_t align) 
+    {
+        /// TODO: Add assertion
+        /// assert that it is a power of 2 and a multiple of sizeof(void*) 
+        /// https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
+
+        auto level = calculateLevel(size, align);
+
+        std::lock_guard lock(mutex);
+        auto * block = allocateBlock(level);
+        setPointerLevel(block, level);
+
+        /// TODO: Remove temp local dummy memory tracker
+        free_min_blocks -= (1ull << ((number_of_levels - level) - 1));
+
+        return block->data;
+    }
+
+    void deallocate(void * buf, size_t size) noexcept
+    {
+        auto * block = reinterpret_cast<MemoryBlock *>(buf);
+        auto level = calculateLevel(size);
+
+        std::lock_guard lock(mutex);
+        deallocateBlock(block, level);
+
+        free_min_blocks += (1ull << ((number_of_levels - level) - 1));
+    }
+
+    void deallocate(void * buf) noexcept
+    {
+        auto * block = reinterpret_cast<MemoryBlock *>(buf);
+        auto level = getPointerLevel(block);
+
+        std::lock_guard lock(mutex);
+        deallocateBlock(block, level);
+
+        free_min_blocks += (1ull << ((number_of_levels - level) - 1));
+    }
+
+private:
+    void * arena_buffer;
+
+    size_t number_of_levels = 0;
+    size_t total_size_bytes = 0;
+
+    size_t minimal_allocation_size_bytes = 0;
+
+    size_t free_min_blocks = 0;
+    size_t min_blocks_num = 0;
+
+    std::mutex mutex;
+
+    bool * block_status;
+    uint8_t * pointers_levels;
+    MemoryBlock ** free_lists;
+
+    [[nodiscard]] static void * allocateArena(size_t size) 
+    {
+        void * buffer = mmap(nullptr, size, PROT_READ | PROT_WRITE, 
+                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, /*fd=*/ -1, /*offset=*/ 0);
+        if (MAP_FAILED == buffer)
+            DB::throwFromErrno(fmt::format("BuddyArena: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+        return buffer;
+    }
+
+    static void deallocateArena(void * buffer, size_t size) 
+    {
+        if (0 != munmap(buffer, size))
+            DB::throwFromErrno(fmt::format("Allocator: Cannot munmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_MUNMAP);
+    }
+
+    void * allocateImpl(size_t level) 
+    {
+        std::lock_guard lock(mutex);
+        auto * block = allocateBlock(level);
+        setPointerLevel(block, level);
+
+        /// TODO: Remove temporarly internal dummy memory tracker after integration with global
+        /// memory tracker
+        free_min_blocks -= (1ull << ((number_of_levels - level) - 1));
+
+        return block->data;
+    }
+
+    size_t calculateLevel(size_t size) const 
+    {
+        // TODO: optimize
+        size_t current_level = number_of_levels - 1;
+        size_t current_block_size = calculateBlockSizeOnLevel(current_level);
+
+        while (size > current_block_size) 
+        {
+            // Low in memory
+            if (current_level == 0) 
+                DB::throwFromErrno(fmt::format("BuddyArena: Cannot allocate enough memory {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+            --current_level;
+            current_block_size *= 2;
+        }
+
+        return current_level;
+    }
+
+    size_t calculateLevel(size_t size, size_t align) const 
+    {
+        if (align < size) 
+            /// Will be automatically aligned if align is valid (as it will be power of 2 that less than size)
+            return calculateLevel(size);
+        else 
+            return calculateLevel(align);
+    }
+
+    size_t calculateBlockSizeOnLevel(size_t level) const 
+    {
+        return total_size_bytes / (1u << level);
+    }
+
+    size_t calculateIndexInLevel(const MemoryBlock * block, size_t level) const 
+    {
+        const auto * block_data = reinterpret_cast<const char *>(block);
+        const auto * arena_data = static_cast<const char *>(arena_buffer);
+        return (block_data - arena_data) / calculateBlockSizeOnLevel(level);
+    }
+
+    size_t calculateIndex(const MemoryBlock * block, size_t level) const 
+    {
+        return (1ull << level) + calculateIndexInLevel(block, level) - 1ull;
+    }
+
+    size_t calculatePointerIndex(const MemoryBlock * block) const 
+    {
+        const auto * block_data = reinterpret_cast<const char *>(block);
+        const auto * arena_data = static_cast<const char *>(arena_buffer);
+        
+        return (block_data - arena_data) / calculateBlockSizeOnLevel(number_of_levels - 1);
+    }
+
+    MemoryBlock * blockFromIndexInLevel(size_t index_in_level, size_t level) const 
+    {
+        auto block_size = calculateBlockSizeOnLevel(level); 
+        return reinterpret_cast<MemoryBlock *>(static_cast<char *>(arena_buffer) + block_size * index_in_level);
+    }
+
+    /// Calculate number of minimal blocks for the allocation on the lower level
+    size_t calculateMinBlocksNumber(size_t size_bytes) const
+    {
+        return size_bytes / minimal_allocation_size_bytes + (size_bytes % minimal_allocation_size_bytes == 0 ? 0 : 1);
+    }
+
+    size_t getPointerLevel(const MemoryBlock * block) const 
+    {
+        const auto pointer_index = calculatePointerIndex(block);
+        return pointers_levels[pointer_index];
+    }
+
+    void setPointerLevel(const MemoryBlock * block, size_t level) 
+    {
+        const auto pointer_index = calculatePointerIndex(block);
+        pointers_levels[pointer_index] = level;
+    }
+
+    MemoryBlock * allocateBlock(size_t level) 
+    {
+        // Found free block in the list
+        if (!isFreeListEmpty(level))
+        {
+            auto * free_block = free_lists[level];
+            removeFromFreeList(free_block, level);
+            return free_block;
+        }
+
+        // There are no free blocks on this level, allocate one from the top
+
+        // Already on the top
+        if (level == 0) 
+            DB::throwFromErrno(fmt::format("BuddyArena: Cannot allocate enough memory."), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+        auto * bigger_block = allocateBlock(level - 1);
+        auto [block, buddy_block] = divideBlock(bigger_block, level - 1);
+        addToFreeList(buddy_block, level);
+
+        return block;
+    }
+
+    char * initializeMetaStorage() 
+    {
+        // Calculate sizes
+        size_t block_status_size = (1ull << number_of_levels) - 1ull;
+        size_t block_status_size_bytes = sizeof(bool) * block_status_size;
+        size_t block_status_size_minimal_blocks = calculateMinBlocksNumber(block_status_size_bytes);
+
+        size_t free_lists_size_bytes = sizeof(MemoryBlock *) * number_of_levels;
+        size_t free_lists_size_minimal_blocks = calculateMinBlocksNumber(free_lists_size_bytes);
+
+        size_t pointers_levels_size = (1ull << (number_of_levels - 1));
+        size_t pointers_levels_size_bytes = sizeof(uint8_t) * pointers_levels_size;
+        size_t pointers_levels_size_minmal_blocks = calculateMinBlocksNumber(pointers_levels_size_bytes);
+        
+        // Populate pointers 
+        auto * current_storage_ptr = reinterpret_cast<char *>(arena_buffer);
+
+        block_status = reinterpret_cast<bool *>(current_storage_ptr);
+        current_storage_ptr += block_status_size_minimal_blocks * minimal_allocation_size_bytes;
+
+        free_lists = reinterpret_cast<MemoryBlock **>(current_storage_ptr);
+        current_storage_ptr += free_lists_size_minimal_blocks * minimal_allocation_size_bytes;
+
+        pointers_levels = reinterpret_cast<uint8_t *>(current_storage_ptr);
+        current_storage_ptr += pointers_levels_size_minmal_blocks * minimal_allocation_size_bytes;
+
+        return current_storage_ptr;
+    }
+
+    void deallocateBlock(MemoryBlock * block, size_t level) 
+    {
+        assert(block);
+
+        auto * buddy = getBuddy(block, level);
+
+        if (buddy && getBlockStatus(buddy, level)) 
+        {
+            // Merge with buddy
+            auto * merged_block = mergeWithBuddy(block, buddy);
+            removeFromFreeList(buddy, level);
+            deallocateBlock(merged_block, level - 1);
+        } else 
+        {
+            addToFreeList(block, level);
+        }  
+    }
+
+    std::pair<MemoryBlock *, MemoryBlock *> divideBlock(
+        MemoryBlock * block, size_t level) 
+    {
+        auto block_size = calculateBlockSizeOnLevel(level);
+
+        // TODO: Can be optimized
+        auto * block_data = reinterpret_cast<char *>(block);
+        auto * buddy_block_data = block_data + block_size / 2;
+
+        auto * memory_block = reinterpret_cast<MemoryBlock *>(block_data);
+        auto * buddy_memory_block = reinterpret_cast<MemoryBlock *>(buddy_block_data);
+
+        return {memory_block, buddy_memory_block};
+    }
+
+    static MemoryBlock * mergeWithBuddy(MemoryBlock * block, MemoryBlock * buddy)
+    {
+        assert(block);
+        assert(buddy);
+
+        auto * block_data = reinterpret_cast<char *>(block);
+        auto * buddy_block_data = reinterpret_cast<char *>(buddy);
+
+        if (block_data < buddy_block_data) 
+            return reinterpret_cast<MemoryBlock *>(block_data);
+        else 
+            return reinterpret_cast<MemoryBlock *>(buddy_block_data);
+    }
+
+    MemoryBlock * getBuddy(MemoryBlock * block, size_t level) const 
+    {
+        auto index_in_level = calculateIndexInLevel(block, level);
+        size_t buddy_index_in_level = index_in_level % 2 == 0 ? index_in_level + 1 : index_in_level - 1;
+        return blockFromIndexInLevel(buddy_index_in_level, level);
+    }
+
+    bool getBlockStatus(const MemoryBlock * block, size_t level)
+    {
+        auto index_of_block = calculateIndex(block, level);
+        return block_status[index_of_block];
+    }
+
+    void setBlockStatus(const MemoryBlock * block, size_t level, bool status)
+    {
+        auto index_of_block = calculateIndex(block, level);
+        block_status[index_of_block] = status; 
+    }
+
+    /// TODO: Remove this method
+    /// Temporarly use only
+    void printMemoryUsageDummy() const 
+    {
+        auto occupied_blocks = min_blocks_num - free_min_blocks;
+        double usage = static_cast<double>(occupied_blocks) / min_blocks_num * 100.0;
+        std::cout << "***Memory usage: " << occupied_blocks << " / " << min_blocks_num << " (" << std::fixed << std::setprecision(1) << usage << " %)***" << std::endl;
+    }
+
+    void addToFreeList(MemoryBlock * block, size_t level) 
+    {
+        setBlockStatus(block, level, true);
+
+        auto & free_list = free_lists[level];
+
+        if (free_list) 
+        {
+            block->pointers.next = free_list;
+            block->pointers.previous = nullptr;
+            free_list->pointers.previous = block;
+        } else 
+        {
+            block->pointers.next = nullptr;
+            block->pointers.previous = nullptr;
+        }
+
+        free_list = block;
+    }
+
+    bool isFreeListEmpty(size_t level) const 
+    {
+        return free_lists[level] == nullptr;
+    }
+
+    void removeFromFreeList(MemoryBlock * block, size_t level) 
+    {
+        assert(!isFreeListEmpty(level));
+
+        setBlockStatus(block, level, false);
+
+        if (block->pointers.next) 
+            block->pointers.next->pointers.previous = block->pointers.previous;
+
+        if (block->pointers.previous) 
+            block->pointers.previous->pointers.next = block->pointers.next;
+
+        /// Move the end of the list if we delete it
+        if (block == free_lists[level]) 
+            free_lists[level] = block->pointers.next;
+
+        block->pointers.next = nullptr;
+        block->pointers.previous = nullptr;
+    }
+};
+
+class BuddyAllocator
+{
+public:
+    /// Allocate memory range.
+    static void * alloc(size_t size, size_t alignment = 0)
+    {
+        checkSize(size);
+        CurrentMemoryTracker::alloc(size);
+        return allocNoTrack(size, alignment);
+    }
+
+    /// Free memory range.
+    static void free(void * buf, size_t size)
+    {
+        try
+        {
+            checkSize(size);
+            freeNoTrack(buf, size);
+            CurrentMemoryTracker::free(size);
+        }
+        catch (...)
+        {
+            DB::tryLogCurrentException("Allocator::free");
+            throw;
+        }
+    }
+
+    /** Enlarge memory range.
+      * Data from old range is moved to the beginning of new range.
+      * Address of memory range could change.
+      */
+    static void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0)
+    {
+        checkSize(new_size);
+
+        if (old_size == new_size)
+        {
+            /// nothing to do.
+            /// BTW, it's not possible to change alignment while doing realloc.
+        }
+        else
+        {
+            /// Big allocs that requires a copy. MemoryTracker is called inside 'alloc', 'free' methods.
+
+            void * new_buf = alloc(new_size, alignment);
+            memcpy(new_buf, buf, std::min(old_size, new_size));
+            free(buf, old_size);
+            buf = new_buf;
+        }
+
+        return buf;
+    }
+
+private:
+    static void checkSize(size_t size)
+    {
+        /// More obvious exception in case of possible overflow (instead of just "Cannot mmap").
+        if (size >= 0x8000000000000000ULL)
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Too large size ({}) passed to allocator. It indicates an error.", size);
+    }
+
+    static void * allocNoTrack(size_t size, size_t /*alignment = 0*/) 
+    {
+        return BuddyArena::instance().allocate(size);
+    }
+
+    static void freeNoTrack(void * buf, size_t size)
+    {
+        BuddyArena::instance().deallocate(buf, size);
+    }
+};
+
+}

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdio>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 
@@ -8,6 +9,8 @@
 #include <Common/Concepts.h>
 #include <Common/CurrentMemoryTracker.h>
 #include "config.h"
+
+#include <Common/UnifiedCache.h>
 
 #if USE_JEMALLOC
 #    include <jemalloc/jemalloc.h>
@@ -30,10 +33,21 @@ requires DB::OptionalArgument<TAlign...>
 inline ALWAYS_INLINE void * newImpl(std::size_t size, TAlign... align)
 {
     void * ptr = nullptr;
+    auto & instance = DB::BuddyArena::instance();
     if constexpr (sizeof...(TAlign) == 1)
-        ptr = aligned_alloc(alignToSizeT(align...), size);
+    {
+        if (instance.isValid())
+            ptr = instance.allocate(size, alignToSizeT(align...));
+        else
+            ptr = aligned_alloc(alignToSizeT(align...), size);
+    } 
     else
-        ptr = malloc(size);
+    {
+        if (instance.isValid())
+            ptr = instance.allocate(size);
+        else
+            ptr = malloc(size);
+    }
 
     if (likely(ptr != nullptr))
         return ptr;
@@ -44,17 +58,29 @@ inline ALWAYS_INLINE void * newImpl(std::size_t size, TAlign... align)
 
 inline ALWAYS_INLINE void * newNoExept(std::size_t size) noexcept
 {
-    return malloc(size);
+    auto & instance = DB::BuddyArena::instance();
+    if (instance.isValid())
+        return instance.allocate(size);
+    else
+        return malloc(size);
 }
 
 inline ALWAYS_INLINE void * newNoExept(std::size_t size, std::align_val_t align) noexcept
 {
-    return aligned_alloc(static_cast<size_t>(align), size);
+    auto & instance = DB::BuddyArena::instance();
+    if (instance.isValid())
+        return instance.allocate(size, static_cast<size_t>(align));
+    else 
+        return aligned_alloc(static_cast<size_t>(align), size);
 }
 
 inline ALWAYS_INLINE void deleteImpl(void * ptr) noexcept
 {
-    free(ptr);
+    auto & instance = DB::BuddyArena::instance();
+    if (instance.isValid() && instance.containsPtr(ptr))
+        instance.deallocate(ptr);
+    else
+        free(ptr);
 }
 
 #if USE_JEMALLOC
@@ -66,10 +92,19 @@ inline ALWAYS_INLINE void deleteSized(void * ptr, std::size_t size, TAlign... al
     if (unlikely(ptr == nullptr))
         return;
 
-    if constexpr (sizeof...(TAlign) == 1)
-        sdallocx(ptr, size, MALLOCX_ALIGN(alignToSizeT(align...)));
-    else
-        sdallocx(ptr, size, 0);
+    auto & instance = DB::BuddyArena::instance();
+    if (instance.isValid() && instance.containsPtr(ptr)) 
+    {
+        instance.deallocate(ptr);
+    }
+    else 
+    {
+        if constexpr (sizeof...(TAlign) == 1)
+            sdallocx(ptr, size, MALLOCX_ALIGN(alignToSizeT(align...)));
+        else
+            sdallocx(ptr, size, 0);
+
+    }
 }
 
 #else
@@ -122,6 +157,12 @@ template <std::same_as<std::align_val_t>... TAlign>
 requires DB::OptionalArgument<TAlign...>
 inline ALWAYS_INLINE void untrackMemory(void * ptr [[maybe_unused]], std::size_t size [[maybe_unused]] = 0, TAlign... align [[maybe_unused]]) noexcept
 {
+    auto & instance = DB::BuddyArena::instance();
+    if (instance.isValid() && instance.containsPtr(ptr))  {
+        CurrentMemoryTracker::free(size);
+        return;
+    }
+
     try
     {
 #if USE_JEMALLOC

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -36,14 +36,14 @@ inline ALWAYS_INLINE void * newImpl(std::size_t size, TAlign... align)
     auto & instance = DB::BuddyArena::instance();
     if constexpr (sizeof...(TAlign) == 1)
     {
-        if (instance.isValid())
+        if (size >= DB::UNIFIED_ALLOC_THRESHOLD && instance.isValid())
             ptr = instance.malloc(size, alignToSizeT(align...));
         else
             ptr = aligned_alloc(alignToSizeT(align...), size);
     } 
     else
     {
-        if (instance.isValid())
+        if (size >= DB::UNIFIED_ALLOC_THRESHOLD && instance.isValid())
             ptr = instance.malloc(size);
         else
             ptr = malloc(size);
@@ -59,7 +59,7 @@ inline ALWAYS_INLINE void * newImpl(std::size_t size, TAlign... align)
 inline ALWAYS_INLINE void * newNoExept(std::size_t size) noexcept
 {
     auto & instance = DB::BuddyArena::instance();
-    if (instance.isValid())
+    if (size >= DB::UNIFIED_ALLOC_THRESHOLD && instance.isValid())
         return instance.malloc(size);
     else
         return malloc(size);
@@ -68,7 +68,7 @@ inline ALWAYS_INLINE void * newNoExept(std::size_t size) noexcept
 inline ALWAYS_INLINE void * newNoExept(std::size_t size, std::align_val_t align) noexcept
 {
     auto & instance = DB::BuddyArena::instance();
-    if (instance.isValid())
+    if (size >= DB::UNIFIED_ALLOC_THRESHOLD && instance.isValid())
         return instance.malloc(size, static_cast<size_t>(align));
     else 
         return aligned_alloc(static_cast<size_t>(align), size);

--- a/src/Formats/MarkInCompressedFile.h
+++ b/src/Formats/MarkInCompressedFile.h
@@ -4,6 +4,7 @@
 
 #include <base/types.h>
 #include <IO/WriteHelpers.h>
+#include "Common/UnifiedCache.h"
 #include <Common/PODArray.h>
 
 
@@ -40,7 +41,7 @@ struct MarkInCompressedFile
 
 };
 
-class MarksInCompressedFile : public PODArray<MarkInCompressedFile>
+class MarksInCompressedFile : public PODArray<MarkInCompressedFile, 4096, BuddyAllocator>
 {
 public:
     explicit MarksInCompressedFile(size_t n) : PODArray(n) {}

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Common/UnifiedCache.h"
 #include <Common/SipHash.h>
 #include <Common/ProfileEvents.h>
 #include <Common/HashTable/Hash.h>
@@ -20,7 +21,7 @@ namespace DB
 
 struct UncompressedCacheCell
 {
-    Memory<> data;
+    Memory<BuddyAllocator> data;
     size_t compressed_size;
     UInt32 additional_bytes;
 };

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1762,14 +1762,14 @@ ThreadPool & Context::getLoadMarksThreadpool() const
     return *shared->load_marks_threadpool;
 }
 
-void Context::setIndexUncompressedCache(size_t max_size_in_bytes)
+void Context::setIndexUncompressedCache(size_t max_size_in_bytes, const String & index_uncompressed_cache_policy)
 {
     auto lock = getLock();
 
     if (shared->index_uncompressed_cache)
         throw Exception("Index uncompressed cache has been already created.", ErrorCodes::LOGICAL_ERROR);
 
-    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(max_size_in_bytes);
+    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(max_size_in_bytes, index_uncompressed_cache_policy);
 }
 
 
@@ -1788,14 +1788,14 @@ void Context::dropIndexUncompressedCache() const
 }
 
 
-void Context::setIndexMarkCache(size_t cache_size_in_bytes)
+void Context::setIndexMarkCache(size_t cache_size_in_bytes, const String & index_mark_cache_policy)
 {
     auto lock = getLock();
 
     if (shared->index_mark_cache)
         throw Exception("Index mark cache has been already created.", ErrorCodes::LOGICAL_ERROR);
 
-    shared->index_mark_cache = std::make_shared<MarkCache>(cache_size_in_bytes);
+    shared->index_mark_cache = std::make_shared<MarkCache>(cache_size_in_bytes, index_mark_cache_policy);
 }
 
 MarkCachePtr Context::getIndexMarkCache() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -813,12 +813,12 @@ public:
     ThreadPool & getLoadMarksThreadpool() const;
 
     /// Create a cache of index uncompressed blocks of specified size. This can be done only once.
-    void setIndexUncompressedCache(size_t max_size_in_bytes);
+    void setIndexUncompressedCache(size_t max_size_in_bytes, const String & index_uncompressed_cache_policy);
     std::shared_ptr<UncompressedCache> getIndexUncompressedCache() const;
     void dropIndexUncompressedCache() const;
 
     /// Create a cache of index marks of specified size. This can be done only once.
-    void setIndexMarkCache(size_t cache_size_in_bytes);
+    void setIndexMarkCache(size_t cache_size_in_bytes, const String & index_mark_cache_policy);
     std::shared_ptr<MarkCache> getIndexMarkCache() const;
     void dropIndexMarkCache() const;
 


### PR DESCRIPTION
# Summary
PoC of the unified cache model with new/delete integration, custom Allocator support and Uncompressed cache and Marks cache integrations.

# Features
- Allocations which go through the new/delete methods or custom BuddyAllocator instances can trigger cache entries eviction from the Uncompressed cache and Marks cache
- All allocations discussed above use the global memory arena that is initialized on the startup
- The trigger for evictions is set up using a threshold of the consumed memory

# Main known problems
- Memory tracker isn't working with this schema
- There are async evictions so there is no guarantee that memory will be released instantly in case of a memory shortage
- Majority of allocations are done through custom Allocator instances (for example PODArray use Allocator class), so it is needed to change Allocator instances to BuddyAllocator to make these structures use BuddyArena 
- Buddy allocator schema isn't very efficient 
- Potential high contention on the global cache policy and global allocator state
- Some allocations can be done aside from BuddyArena (e.g. static constructors cannot use BuddyArena)

# Implementation details
The high-level architecture of the PoC:
![caches (3)](https://user-images.githubusercontent.com/26204649/212958677-1aaea19f-55ca-4c19-8c55-85a485be96b8.png)

More specific diagram:
![caches (8)](https://user-images.githubusercontent.com/26204649/212961211-abf84c88-4ec7-437e-b245-7aabbdb6cea0.png)

You can find components from the picture above in the following places:
- Global allocator state - [BuddyArena class](https://github.com/NikitaEvs/ClickHouse/blob/cd10bf9942721cee95ebabdaa06d931255782e1b/src/Common/UnifiedCache.h#L284)
- Global cache policy - [LRUUnifiedCacheGlobal class](https://github.com/NikitaEvs/ClickHouse/blob/cd10bf9942721cee95ebabdaa06d931255782e1b/src/Common/UnifiedCache.h#L32)
- Custom Allocator instance - [BuddyAllocator class](https://github.com/NikitaEvs/ClickHouse/blob/cd10bf9942721cee95ebabdaa06d931255782e1b/src/Common/UnifiedCache.h#L739)
- [new/delete integration](https://github.com/NikitaEvs/ClickHouse/blob/cd10bf9942721cee95ebabdaa06d931255782e1b/src/Common/memory.h#L36) (and other places in the same file)
- MarksCache [integration](https://github.com/NikitaEvs/ClickHouse/blob/cd10bf9942721cee95ebabdaa06d931255782e1b/src/Formats/MarkInCompressedFile.h#L44)
- UncompressedCache [integration](https://github.com/NikitaEvs/ClickHouse/blob/cd10bf9942721cee95ebabdaa06d931255782e1b/src/IO/UncompressedCache.h#L24)

# Test plan
The main components of the allocator were tested using separate unit tests, WIP.

# Benchmarks
WIP



