### PR TITLE
Add unified array cache

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -561,15 +561,42 @@ void LocalServer::processConfig()
     global_context->getProcessList().setMaxSize(0);
 
     /// Set up caches.
-    auto block_cache_size = 1000_MiB;
-    auto max_size_to_evict_on_purging = 300_MiB;
-    auto & block_cache_manager = DB::BlockCachesManager<UInt128>::instance();
-    std::vector<std::string> block_cache_names = {"global"};
-    std::string rebalance_strategy_name = "dummy";
-    BlockCacheSettingsMapping cache_settings;
-    cache_settings["global"] = {.cache_max_size = block_cache_size, .max_size_to_evict_on_purging = max_size_to_evict_on_purging};
 
-    block_cache_manager.initialize(block_cache_names, rebalance_strategy_name, cache_settings);
+    /// Dummy strategy
+    // auto block_cache_size = 1000_MiB;
+    // auto max_size_to_evict_on_purging = 300_MiB;
+    // std::string rebalance_strategy_name = "dummy";
+    // RebalanceStrategySettings rebalance_strategy_settings;
+    // rebalance_strategy_settings.setBlockCacheSetting("max_total_size", "marks", Field(block_cache_size));
+    // rebalance_strategy_settings.setBlockCacheSetting("max_size_to_evict_on_purging", "marks", Field(max_size_to_evict_on_purging));
+    // rebalance_strategy_settings.setBlockCacheSetting("max_total_size", "uncompressed", Field(block_cache_size));
+    // rebalance_strategy_settings.setBlockCacheSetting("max_size_to_evict_on_purging", "uncompressed", Field(max_size_to_evict_on_purging));
+
+    /// Buddy static strategy
+    // auto memory_arena_size = 4_GiB;
+    // auto max_size_to_evict_on_purging = 300_MiB;
+    // std::string rebalance_strategy_name = "buddy_static";
+    // RebalanceStrategySettings rebalance_strategy_settings;
+    // rebalance_strategy_settings.set("memory_arena_size", Field(memory_arena_size));
+    // rebalance_strategy_settings.setBlockCacheSetting("max_size_to_evict_on_purging", "marks", Field(max_size_to_evict_on_purging));
+    // rebalance_strategy_settings.setBlockCacheSetting("max_size_to_evict_on_purging", "uncompressed", Field(max_size_to_evict_on_purging));
+
+    /// Buddy dynamic strategy
+    auto memory_arena_capacity = 4_GiB;
+    auto memory_arena_initial_size = 128_MiB;
+    size_t allocated_memory_multiplier = 2;
+    auto max_size_to_evict_on_purging = 300_MiB;
+    std::string rebalance_strategy_name = "buddy_dynamic";
+    RebalanceStrategySettings rebalance_strategy_settings;
+    rebalance_strategy_settings.set("memory_arena_capacity", Field(memory_arena_capacity));
+    rebalance_strategy_settings.set("memory_arena_initial_size", Field(memory_arena_initial_size));
+    rebalance_strategy_settings.set("allocated_memory_multiplier", Field(allocated_memory_multiplier));
+    rebalance_strategy_settings.setBlockCacheSetting("max_size_to_evict_on_purging", "marks", Field(max_size_to_evict_on_purging));
+    rebalance_strategy_settings.setBlockCacheSetting("max_size_to_evict_on_purging", "uncompressed", Field(max_size_to_evict_on_purging));
+
+    auto & block_cache_manager = DB::BlockCachesManager<UInt128>::instance();
+    std::vector<std::string> block_cache_names = {"marks", "uncompressed"};
+    block_cache_manager.initialize(block_cache_names, rebalance_strategy_name, rebalance_strategy_settings);
 
     /// Size of cache for uncompressed blocks. Zero means disabled.
     String uncompressed_cache_policy = config().getString("uncompressed_cache_policy", "");

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1146,6 +1146,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
             }
 
             total_memory_tracker.setHardLimit(max_server_memory_usage);
+            /// TODO: Add setting
+            total_memory_tracker.setLimitToPurgeCache(1500_MiB);
             total_memory_tracker.setDescription("(total)");
             total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
 
@@ -1393,10 +1395,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
     global_context->getProcessList().setMaxSize(config().getInt("max_concurrent_queries", 0));
 
     /// Set up caches.
-
-    auto block_cache_size = 2000_MiB;
+    auto block_cache_size = 1000_MiB;
+    auto max_size_to_evict_on_purging = 300_MiB;
     auto & block_cache = DB::GlobalBlockCache<UInt128>::instance();
-    block_cache.initialize(block_cache_size);
+    block_cache.initialize(block_cache_size, max_size_to_evict_on_purging);
 
     /// Lower cache size on low-memory systems.
     double cache_size_to_ram_max_ratio = config().getDouble("cache_size_to_ram_max_ratio", 0.5);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1417,8 +1417,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Buddy dynamic strategy
     auto memory_arena_capacity = 4_GiB;
-    auto memory_arena_initial_size = 128_MiB;
-    size_t allocated_memory_multiplier = 2;
+    UInt64 memory_arena_initial_size = 0;
+    size_t allocated_memory_multiplier = 1;
     auto max_size_to_evict_on_purging = 300_MiB;
     std::string rebalance_strategy_name = "buddy_dynamic";
     RebalanceStrategySettings rebalance_strategy_settings;

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -11,6 +11,7 @@
 #include <Poco/Net/NetException.h>
 #include <Poco/Util/HelpFormatter.h>
 #include <Poco/Environment.h>
+#include <Common/UnifiedCache.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/logger_useful.h>
 #include <base/phdr_cache.h>
@@ -1392,6 +1393,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
     global_context->getProcessList().setMaxSize(config().getInt("max_concurrent_queries", 0));
 
     /// Set up caches.
+
+    auto block_cache_size = 2000_MiB;
+    auto & block_cache = DB::GlobalBlockCache<UInt128>::instance();
+    block_cache.initialize(block_cache_size);
 
     /// Lower cache size on low-memory systems.
     double cache_size_to_ram_max_ratio = config().getDouble("cache_size_to_ram_max_ratio", 0.5);

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -242,7 +242,7 @@ void MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryT
     /// TODO: Rewrite with a rebalance strategy
     if (unlikely(current_limit_to_purge_cache && will_be > current_limit_to_purge_cache))
     {
-        auto & cache_instance = DB::GlobalBlockCache<UInt128>::instance();
+        auto & cache_instance = DB::BlockCachesManager<UInt128>::instance();
         /// TODO: Make a better shrinkage with a relative ration to the full amount of memory
         cache_instance.purge();
     }

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -55,6 +55,7 @@ private:
     std::atomic<Int64> soft_limit {0};
     std::atomic<Int64> hard_limit {0};
     std::atomic<Int64> profiler_limit {0};
+    std::atomic<Int64> limit_to_purge_cache {0};
 
     static std::atomic<Int64> free_memory_in_allocator_arenas;
 
@@ -116,6 +117,7 @@ public:
 
     void setSoftLimit(Int64 value);
     void setHardLimit(Int64 value);
+    void setLimitToPurgeCache(Int64 value);
 
     Int64 getHardLimit() const
     {
@@ -124,6 +126,10 @@ public:
     Int64 getSoftLimit() const
     {
         return soft_limit.load(std::memory_order_relaxed);
+    }
+    Int64 getLimitToPurgeCache() const 
+    {
+        return limit_to_purge_cache.load(std::memory_order_relaxed);     
     }
 
     /** Set limit if it was not set.

--- a/src/Common/UnifiedCache.cpp
+++ b/src/Common/UnifiedCache.cpp
@@ -1,0 +1,259 @@
+#include <Common/UnifiedCache.h>
+#include <Core/Types.h>
+#include <base/getPageSize.h>
+#include <atomic>
+#include <cstdlib>
+#include <sys/mman.h>
+
+namespace DB 
+{
+
+template <typename Key>
+BlockCache<Key>::Chunk::Chunk(size_t size_) : size(size_)
+{
+    ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (MAP_FAILED == ptr)
+        DB::throwFromErrno(fmt::format("BlockCache: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+}
+
+template <typename Key>
+BlockCache<Key>::Chunk::~Chunk()
+{
+    if (ptr && 0 != munmap(ptr, size))
+        DB::throwFromErrno(fmt::format("BlockCache: Cannot munmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_MUNMAP);
+}
+
+template <typename Key>
+BlockCache<Key>::Holder::Holder(BlockCache<Key> & cache_, BlockCache<Key>::RegionMetadata & region_, std::lock_guard<std::mutex>&)
+    : cache(cache_)
+    , region(region_)
+    , region_ptr(&region_)
+{
+    /// Remove this region from the lru_list, so we can't evict it
+    if (++region.refcount == 1 && region.LRUListHook::is_linked())
+        cache.lru_list.erase(cache.lru_list.iterator_to(region));
+}
+
+template <typename Key>
+BlockCache<Key>::Holder::~Holder()
+{
+    /// Add this region to the lru_list if there are no references 
+    std::lock_guard cache_lock(cache.mutex);
+    if (--region.refcount == 0)
+        cache.lru_list.push_back(region);
+}
+
+template <typename Key>
+typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::addNewChunk(size_t size)
+{
+    chunks.emplace_back(size);
+    auto & chunk = chunks.back();
+
+    total_chunks_size += size;
+
+    auto * free_region = RegionMetadata::create();
+    free_region->ptr = chunk.ptr;
+    assert(free_region->ptr != nullptr);
+    free_region->chunk = chunk.ptr;
+    free_region->size = chunk.size;
+
+    adjacency_list.push_back(*free_region);
+    size_multimap.insert(*free_region);
+
+    return free_region;
+}
+
+/// Precondition: free_region.size >= size.
+template <typename Key>
+typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::allocateFromFreeRegion(typename BlockCache<Key>::RegionMetadata * free_region, size_t size)
+{
+    if (!free_region)
+        return nullptr;
+
+    if (free_region->size == size)
+    {
+        size_multimap.erase(size_multimap.iterator_to(*free_region));
+        return free_region;
+    }
+
+    auto * allocated_region = RegionMetadata::create();
+    allocated_region->ptr = free_region->ptr;
+    assert(allocated_region->ptr != nullptr);
+    allocated_region->chunk = free_region->chunk;
+    allocated_region->size = size;
+
+    size_multimap.erase(size_multimap.iterator_to(*free_region));
+    free_region->size -= size;
+    free_region->char_ptr += size;
+    size_multimap.insert(*free_region);
+
+    adjacency_list.insert(adjacency_list.iterator_to(*free_region), *allocated_region);
+    return allocated_region;
+}
+
+static size_t roundUp(size_t x, size_t rounding)
+{
+    return (x + (rounding - 1)) / rounding * rounding;
+}
+
+template <typename Key>
+typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::allocate(size_t size)
+{
+    size = roundUp(size, alignment);
+
+    /// Look up to size multimap to find free region of specified size.
+    auto it = size_multimap.lower_bound(size, RegionCompareBySize());
+    if (size_multimap.end() != it)
+        return allocateFromFreeRegion(&*it, size);
+
+    /// If nothing was found and total size of allocated chunks plus required size is lower than maximum,
+    ///  allocate a new chunk.
+    size_t page_size = static_cast<size_t>(::getPageSize());
+    size_t required_chunk_size = std::max(min_chunk_size, roundUp(size, page_size));
+    if (total_chunks_size + required_chunk_size <= max_total_size)
+    {
+        /// Create free region spanning through chunk.
+        RegionMetadata * free_region = addNewChunk(required_chunk_size);
+        return allocateFromFreeRegion(free_region, size);
+    }
+
+    while (true)
+    {
+        RegionMetadata * res = evictSome(size);
+
+        /// Nothing to evict. All cache is full and in use - cannot allocate memory.
+        if (!res)
+            return nullptr;
+
+        /// Not enough. Evict more.
+        if (res->size < size)
+            continue;
+
+        return allocateFromFreeRegion(res, size);
+    }
+}
+
+/// Precondition: region is not in lru_list, not in key_map, not in size_multimap.
+/// Postcondition: region is not in lru_list, not in key_map,
+///  inserted into size_multimap, possibly coalesced with adjacent free regions.
+template <typename Key>
+void BlockCache<Key>::freeRegion(typename BlockCache<Key>::RegionMetadata * region) noexcept
+{
+    if (!region)
+        return;
+
+    auto adjacency_list_it = adjacency_list.iterator_to(*region);
+
+    auto left_it = adjacency_list_it;
+    if (left_it != adjacency_list.begin())
+    {
+        --left_it;
+
+        if (left_it->chunk == region->chunk && left_it->isFree())
+        {
+            region->size += left_it->size;
+            region->char_ptr -= left_it->size; 
+            size_multimap.erase(size_multimap.iterator_to(*left_it));
+            adjacency_list.erase_and_dispose(left_it, [](RegionMetadata * elem) { elem->destroy(); });
+        }
+    }
+
+    auto right_it = adjacency_list_it;
+    ++right_it;
+    if (right_it != adjacency_list.end())
+    {
+        if (right_it->chunk == region->chunk && right_it->isFree())
+        {
+            region->size += right_it->size;
+            size_multimap.erase(size_multimap.iterator_to(*right_it));
+            adjacency_list.erase_and_dispose(right_it, [](RegionMetadata * elem) { elem->destroy(); });
+        }
+    }
+
+    size_multimap.insert(*region);
+}
+
+template <typename Key>
+void BlockCache<Key>::evictRegion(RegionMetadata * evicted_region) noexcept
+{
+    lru_list.erase(lru_list.iterator_to(*evicted_region));
+
+    if (evicted_region->KeyMapHook::is_linked())
+        key_map.erase(key_map.iterator_to(*evicted_region));
+
+    freeRegion(evicted_region);
+}
+
+/// Evict region from cache and return it, coalesced with nearby free regions.
+/// While size is not enough, evict adjacent regions at right, if any.
+/// If nothing to evict, returns nullptr.
+/// Region is removed from lru_list and key_map and inserted into size_multimap.
+template <typename Key>
+typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::evictSome(size_t requested_size) noexcept
+{
+    if (lru_list.empty()) 
+        return nullptr;
+
+    auto it = adjacency_list.iterator_to(lru_list.front());
+
+    while (true)
+    {
+        RegionMetadata & evicted_region = *it;
+        evictRegion(&evicted_region);
+
+        /// Statistics
+        total_useful_cache_size.fetch_sub(evicted_region.size, std::memory_order_relaxed);
+        total_useful_cache_count.fetch_sub(1, std::memory_order_relaxed);
+
+        if (evicted_region.size >= requested_size)
+            return &evicted_region;
+
+        ++it;
+        if (it == adjacency_list.end() || it->chunk != evicted_region.chunk || !it->LRUListHook::is_linked())
+            return &evicted_region;
+    }
+}
+
+template <typename Key>
+BlockCache<Key>::~BlockCache()
+{
+    key_map.clear();
+    size_multimap.clear();
+    lru_list.clear();
+    adjacency_list.clear_and_dispose([](RegionMetadata * elem) { elem->destroy(); });
+}
+
+template <typename Key>
+typename BlockCache<Key>::HolderPtr BlockCache<Key>::get(const Key & key)
+{
+    std::lock_guard cache_lock(mutex);    
+
+    auto it = key_map.find(key, RegionCompareByKey());
+    if (key_map.end() != it)
+    {
+        return new Holder(*this, *it, cache_lock);
+    }
+    return nullptr;
+}
+
+template <typename Key>
+void BlockCache<Key>::reset()
+{
+
+}
+
+template <typename Key>
+size_t BlockCache<Key>::getCacheWeight() const
+{
+    return total_useful_cache_size.load(std::memory_order_relaxed);
+}
+
+template <typename Key>
+size_t BlockCache<Key>::getCacheCount() const
+{
+    return total_useful_cache_count.load(std::memory_order_relaxed);
+}
+
+template class BlockCache<UInt128>;
+
+}

--- a/src/Common/UnifiedCache.cpp
+++ b/src/Common/UnifiedCache.cpp
@@ -1,25 +1,572 @@
 #include <Common/UnifiedCache.h>
-#include "Access/ContextAccess.h"
+#include "Core/Block.h"
 #include <Core/Types.h>
 #include <base/getPageSize.h>
 #include <atomic>
 #include <cstdlib>
+#include <mutex>
 #include <string_view>
 #include <sys/mman.h>
 
 namespace DB 
 {
 
-MemoryBlock::MemoryBlock(size_t size_) : size(size_)
+BuddyArena::~BuddyArena() noexcept
+{
+    if (isValid())
+        // Do not throw exceptions from invalid munmap
+        munmap(arena_buffer, total_size_bytes);
+}
+
+bool BuddyArena::isValid() const
+{
+    return number_of_levels != 0;
+}
+
+bool BuddyArena::isAllocated(const void *ptr) const
+{
+    const auto * arena_end = reinterpret_cast<char *>(arena_buffer) + total_size_bytes;
+    return ptr >= arena_buffer && ptr < reinterpret_cast<const void *>(arena_end); 
+}
+
+void BuddyArena::initialize(size_t minimal_allocation_size, size_t size, size_t capacity)
+{
+    /// We will divide the whole size bytes on blocks with size == minimal_allocation_size
+    assert(size % minimal_allocation_size == 0);
+    assert(capacity % minimal_allocation_size == 0);
+    assert(capacity >= size);
+
+    total_size_bytes = capacity;
+    number_of_levels = 1;
+    minimal_allocation_size_bytes = minimal_allocation_size;
+
+    /// Calculate number of levels
+    size_t number_of_blocks_on_level = capacity / minimal_allocation_size; 
+
+    /// Number of blocks on the level could not be the power of 2
+    /// In this case we intentionally add one level to the binary tree so we'll have enough 
+    /// leaves to store all minimal blocks
+    if (number_of_blocks_on_level > 1 && number_of_blocks_on_level % 2 != 0) 
+        ++number_of_levels;
+
+    while (number_of_blocks_on_level > 1) 
+    {
+        number_of_blocks_on_level >>= 1;
+        ++number_of_levels;
+    }
+
+    /// Calculate number of minimal blocks in the memory arena
+    min_blocks_num = (1ull << (number_of_levels - 1));
+    // free_min_blocks = min_blocks_num;
+
+    arena_buffer = allocateArena(total_size_bytes);
+    const auto * arena_buffer_char_ptr = reinterpret_cast<const char *>(arena_buffer);
+
+    auto * current_storage_ptr = initializeMetaStorage();
+
+    // TODO: Optimize
+    /// Initialize free_lists
+
+    /// Calculate number of blocks for the meta storage
+    size_t meta_storage_size_minimal_blocks = (current_storage_ptr - arena_buffer_char_ptr) / minimal_allocation_size_bytes;
+
+    /// Calculate the nearest power of 2 that is greater than meta storage size
+    size_t meta_storage_size_round_up_to_power_of_2 = 1;
+    while (meta_storage_size_round_up_to_power_of_2 < meta_storage_size_minimal_blocks) 
+    {
+        meta_storage_size_round_up_to_power_of_2 *= 2;
+    }
+
+    /// Deallocate (add to the free_lists or shadow_lists) minimal blocks to fill the space between the meta storage and the size that is
+    /// the nearest power of 2, so after it we can deallocate blocks with an exponential increasing sizes 
+    /// Arena buffer:
+    /// [*******-------------|------------------------------------]
+    ///  |               |   |
+    ///  ^ meta storage  |   ^ meta_storage_size_round_up_to_power_of_2
+    ///                  ^ deallocate these blocks on this step
+    const auto * minimal_blocks_area_end = arena_buffer_char_ptr + meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size_bytes;
+    while (current_storage_ptr != minimal_blocks_area_end) 
+    {
+        auto * memory_block = reinterpret_cast<MemoryBlock *>(current_storage_ptr);
+
+        if (static_cast<size_t>(current_storage_ptr - arena_buffer_char_ptr) < size) 
+        {
+            /// Do not fill the size bytes, add the block to the free_lists and reclaim it from the OS
+            returnBlockToLists(free_lists, memory_block, number_of_levels - 1);
+            reclaimBlock(memory_block, number_of_levels - 1);
+        }
+        else
+        {
+            /// Already filled the size bytes, do not add the block to the free_lists
+            /// Instead add it to the shadow list, so we can track it
+            returnBlockToLists(shadow_lists, memory_block, number_of_levels - 1);
+        }
+
+        current_storage_ptr += minimal_allocation_size_bytes;
+    }
+
+    /// Deallocate (add to the free_lists or shadow_lists) all next blocks after meta_storage_size_round_up_to_power_of_2 with increasing sizes 
+    size_t current_block_size_bytes = meta_storage_size_round_up_to_power_of_2 * minimal_allocation_size;
+    size_t current_block_level = calculateLevel(current_block_size_bytes);
+    while (current_block_level > 0) 
+    {
+        auto * memory_block = reinterpret_cast<MemoryBlock *>(current_storage_ptr);
+
+        /// TODO: Add a separate method: code duplication
+        if (static_cast<size_t>(current_storage_ptr - arena_buffer_char_ptr) < size) 
+        {
+            /// Do not fill the size bytes, add the block to the free_lists and reclaim it from the OS
+            returnBlockToLists(free_lists, memory_block, current_block_level);
+            reclaimBlock(memory_block, current_block_level);
+        }
+        else
+        {
+            /// Already filled the size bytes, do not add the block to the free_lists
+            /// Instead add it to the shadow list, so we can track it
+            returnBlockToLists(shadow_lists, memory_block, current_block_level);
+        }
+
+        current_storage_ptr += current_block_size_bytes;
+        current_block_size_bytes *= 2;
+        --current_block_level;
+    }
+}
+
+void * BuddyArena::malloc(size_t size, size_t align)
+{
+    /// TODO: Add assertion
+    /// assert that align is a power of 2 and a multiple of sizeof(void*) 
+    /// https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
+
+    auto level = calculateLevel(size, align);
+
+    auto * block = allocateBlock(level);
+    if (block == nullptr)
+        block = acquireBlock(level);
+    if (block == nullptr)
+        return nullptr;
+
+    setPointerLevel(block, level);
+
+    /// TODO: Remove temp local dummy memory tracker
+    const size_t allocated_memory_blocks = 1ull << ((number_of_levels - level) - 1);
+    free_min_blocks.fetch_sub(allocated_memory_blocks);
+    // if (free_min_blocks % 10000 == 0) {
+    //     printMemoryUsageDummy();
+    // }
+
+    return block->data;
+}
+
+void BuddyArena::free(void * buf) noexcept
+{
+    auto * block = reinterpret_cast<MemoryBlock *>(buf);
+    auto level = getPointerLevel(block);
+
+    deallocateBlock(block, level);
+
+    /// TODO: Remove temp local dummy memory tracker
+    const size_t freeing_memory_blocks = 1ull << ((number_of_levels - level) - 1);
+    free_min_blocks.fetch_add(freeing_memory_blocks);
+    // if (free_min_blocks % 10000 == 0) {
+    //     printMemoryUsageDummy();
+    // }
+}
+
+void BuddyArena::purge()
+{
+    for (size_t current_level = 0; current_level < number_of_levels; ++current_level) 
+    {
+        while (auto * block = takeBlockFromLists(free_lists, current_level)) 
+            tryReleaseBlock(block, current_level);
+    }
+}
+
+double BuddyArena::getFreeSpaceRatio() const
+{
+    /// TODO: Change seq_cst memory_order on the free_min_blocks atomic
+    auto occupied_blocks = min_blocks_num - free_min_blocks.load();
+    return static_cast<double>(min_blocks_num - occupied_blocks) / min_blocks_num;
+}
+
+size_t BuddyArena::getTotalSizeBytes() const
+{
+    return total_size_bytes;
+}
+
+void * BuddyArena::allocateArena(size_t size)
+{
+    void * buffer = mmap(nullptr, size, PROT_READ | PROT_WRITE, 
+                MAP_PRIVATE | MAP_ANONYMOUS, /*fd=*/ -1, /*offset=*/ 0);
+    if (MAP_FAILED == buffer)
+        DB::throwFromErrno(fmt::format("BuddyArena: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+    return buffer;
+}
+
+void BuddyArena::deallocateArena(void * buffer, size_t size) 
+{
+    // TODO: Not checking the result value
+    munmap(buffer, size);
+}
+
+size_t BuddyArena::calculateLevel(size_t size) const 
+{
+    // TODO: optimize
+    size_t current_level = number_of_levels - 1;
+    size_t current_block_size = calculateBlockSizeOnLevel(current_level);
+
+    while (size > current_block_size) 
+    {
+        // Low in memory
+        if (current_level == 0) 
+            DB::throwFromErrno(fmt::format("BuddyArena: Cannot find level for size {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+
+        --current_level;
+        current_block_size *= 2;
+    }
+
+    return current_level;
+}
+
+size_t BuddyArena::calculateLevel(size_t size, size_t align) const 
+{
+    if (align < size) 
+        /// Will be automatically aligned if align is valid (as it will be power of 2 that less than size)
+        return calculateLevel(size);
+    else 
+        return calculateLevel(align);
+}
+
+size_t BuddyArena::calculateBlockSizeOnLevel(size_t level) const 
+{
+    return minimal_allocation_size_bytes * (1ull << ((number_of_levels - level) - 1));
+}
+
+size_t BuddyArena::calculateIndexInLevel(const MemoryBlock * block, size_t level) const 
+{
+    const auto * block_data = reinterpret_cast<const char *>(block);
+    const auto * arena_data = static_cast<const char *>(arena_buffer);
+    return (block_data - arena_data) / calculateBlockSizeOnLevel(level);
+}
+
+size_t BuddyArena::calculateIndex(const MemoryBlock * block, size_t level) const 
+{
+    return (1ull << level) + calculateIndexInLevel(block, level) - 1ull;
+}
+
+size_t BuddyArena::calculatePointerIndex(const MemoryBlock * block) const 
+{
+    const auto * block_data = reinterpret_cast<const char *>(block);
+    const auto * arena_data = static_cast<const char *>(arena_buffer);
+        
+    return (block_data - arena_data) / calculateBlockSizeOnLevel(number_of_levels - 1);
+}
+
+size_t BuddyArena::calculateMinBlocksNumber(size_t size_bytes) const
+{
+    return size_bytes / minimal_allocation_size_bytes + (size_bytes % minimal_allocation_size_bytes == 0 ? 0 : 1);
+}
+
+BuddyArena::MemoryBlock * BuddyArena::blockFromIndexInLevel(size_t index_in_level, size_t level) const
+{
+    auto block_size = calculateBlockSizeOnLevel(level); 
+    return reinterpret_cast<MemoryBlock *>(static_cast<char *>(arena_buffer) + block_size * index_in_level);
+}
+
+size_t BuddyArena::getPointerLevel(const MemoryBlock * block) const 
+{
+    const auto pointer_index = calculatePointerIndex(block);
+    return pointers_levels[pointer_index];
+}
+
+void BuddyArena::setPointerLevel(const MemoryBlock * block, size_t level) 
+{
+    const auto pointer_index = calculatePointerIndex(block);
+    pointers_levels[pointer_index] = level;
+}
+
+BuddyArena::MemoryBlock * BuddyArena::takeBlockFromLists(GuardedLists & guarded_lists, size_t level)
+{
+    MemoryBlock * current_block = nullptr;
+    size_t current_level = level;
+    do 
+    {
+        std::lock_guard lock(guarded_lists.mutexes[current_level]);
+
+        /// Found a block on this level
+        if (!isListEmpty(guarded_lists.lists, current_level)) 
+        {
+            current_block = guarded_lists.lists[current_level];
+            removeFromList(guarded_lists.lists, current_block, current_level);
+            setBlockStatus(current_block, current_level, BlockStatus::NotInLists);
+            break;
+        }
+
+        /// There are no blocks on this level, go to the top
+        if (current_level == 0)
+            break;
+        --current_level;
+    } while (current_level != 0);
+
+    /// Already on the top without free blocks
+    if (current_block == nullptr) 
+        return nullptr;
+
+    /// Iterate from current_level to the level and split current_block 
+    while (current_level != level) 
+    {
+        auto [block, buddy_block] = divideBlock(current_block, current_level);
+        {
+            std::lock_guard lock(guarded_lists.mutexes[current_level + 1]);
+            addToList(guarded_lists.lists, buddy_block, current_level + 1);
+            setBlockStatus(buddy_block, current_level + 1, guarded_lists.lists_block_status);
+        }
+        current_block = block;
+        ++current_level;
+    }
+
+    return current_block;
+}
+
+void BuddyArena::returnBlockToLists(GuardedLists & guarded_lists, MemoryBlock * block, size_t level)
+{
+    assert(block);
+
+    size_t current_level = level;
+    MemoryBlock * current_block = block;
+    
+    do 
+    {
+        std::lock_guard lock(guarded_lists.mutexes[current_level]);
+
+        auto * buddy = getBuddy(current_block, current_level);
+        if (buddy && (getBlockStatus(buddy, current_level) == guarded_lists.lists_block_status)) 
+        {
+            // Merge with buddy
+            auto * merged_block = mergeWithBuddy(current_block, buddy);
+            removeFromList(guarded_lists.lists, buddy, current_level);
+            setBlockStatus(buddy, current_level, BlockStatus::NotInLists);
+            current_block = merged_block;
+        } else 
+        {
+            addToList(guarded_lists.lists, current_block, current_level);
+            setBlockStatus(current_block, current_level, guarded_lists.lists_block_status);
+            break;
+        }  
+
+        if (current_level == 0)
+            break;
+        --current_level;
+    } while (current_level != 0);
+}
+
+BuddyArena::MemoryBlock * BuddyArena::allocateBlock(size_t level) 
+{
+    return takeBlockFromLists(free_lists, level);
+}
+
+void BuddyArena::deallocateBlock(MemoryBlock * block, size_t level) 
+{
+    returnBlockToLists(free_lists, block, level);
+}
+
+bool BuddyArena::adviseBlock(MemoryBlock * block, size_t level) const
+{
+    const auto block_size = calculateBlockSizeOnLevel(level);
+
+    void * block_ptr = reinterpret_cast<void *>(block->data);
+    auto ret = madvise(block_ptr, block_size, MADV_DONTNEED);
+    return ret == 0;
+}
+
+void BuddyArena::reclaimBlock(MemoryBlock * block, size_t level) const
+{
+    const auto block_size = calculateBlockSizeOnLevel(level);
+    const auto page_num = block_size / kPageSize;
+
+    auto * block_ptr = block->data;
+
+    mlock(reinterpret_cast<void *>(block_ptr), block_size);
+
+    /// Trigger page faults, use volatile to fool the compiler
+    for (size_t page_offset = 0; page_offset < page_num; ++page_offset) {
+        volatile const auto val = *(block_ptr + page_offset * kPageSize);
+        (void)val;
+    }
+}
+
+BuddyArena::MemoryBlock * BuddyArena::acquireBlock(size_t level)
+{
+    auto * block = takeBlockFromLists(shadow_lists, level);
+    if (block != nullptr) 
+        reclaimBlock(block, level);
+    return block;
+}
+
+void BuddyArena::tryReleaseBlock(MemoryBlock * block, size_t level)
+{
+    if (adviseBlock(block, level))
+        returnBlockToLists(shadow_lists, block, level);
+}
+
+char * BuddyArena::initializeMetaStorage() 
+{
+    /// TODD: Note that if there is a big min_allocation_size, we can potentially waste memory on the unnecessary alignment
+    /// Calculate sizes
+    size_t block_status_size = (1ull << number_of_levels) - 1ull;
+    size_t block_status_size_bytes = sizeof(bool) * block_status_size;
+    size_t block_status_size_minimal_blocks = calculateMinBlocksNumber(block_status_size_bytes);
+
+    size_t free_lists_size_bytes = sizeof(MemoryBlock *) * number_of_levels; // NOLINT
+    size_t free_lists_size_minimal_blocks = calculateMinBlocksNumber(free_lists_size_bytes);
+
+    size_t shadow_lists_size_bytes = sizeof(MemoryBlock *) * number_of_levels; // NOLINT
+    size_t shadow_lists_size_minimal_blocks = calculateMinBlocksNumber(shadow_lists_size_bytes);
+
+    size_t pointers_levels_size = (1ull << (number_of_levels - 1));
+    size_t pointers_levels_size_bytes = sizeof(uint8_t) * pointers_levels_size;
+    size_t pointers_levels_size_minmal_blocks = calculateMinBlocksNumber(pointers_levels_size_bytes);
+
+    size_t mutexes_size_bytes = sizeof(std::mutex) * number_of_levels;
+    size_t mutexes_size_minimal_blocks = calculateMinBlocksNumber(mutexes_size_bytes);
+        
+    /// Populate pointers 
+    auto * current_storage_ptr = reinterpret_cast<char *>(arena_buffer);
+
+    block_status = reinterpret_cast<BlockStatus *>(current_storage_ptr);
+    current_storage_ptr += block_status_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    /// Place free_lists.lists and free_lists.mutexes for the better cache locality
+    free_lists.lists = reinterpret_cast<MemoryBlock **>(current_storage_ptr);
+    current_storage_ptr += free_lists_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    free_lists.mutexes = reinterpret_cast<std::mutex *>(current_storage_ptr);
+    current_storage_ptr += mutexes_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    pointers_levels = reinterpret_cast<uint8_t *>(current_storage_ptr);
+    current_storage_ptr += pointers_levels_size_minmal_blocks * minimal_allocation_size_bytes;
+
+    /// Place shadow_lists.lists and shadow_lists.mutexes for the better cache locality
+    shadow_lists.lists = reinterpret_cast<MemoryBlock **>(current_storage_ptr);
+    current_storage_ptr += shadow_lists_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    shadow_lists.mutexes = reinterpret_cast<std::mutex *>(current_storage_ptr);
+    current_storage_ptr += mutexes_size_minimal_blocks * minimal_allocation_size_bytes;
+
+    return current_storage_ptr;
+}
+
+std::pair<BuddyArena::MemoryBlock *, BuddyArena::MemoryBlock *> BuddyArena::divideBlock(
+    MemoryBlock * block, size_t level) 
+{
+    auto block_size = calculateBlockSizeOnLevel(level);
+
+    // TODO: Can be optimized
+    auto * block_data = reinterpret_cast<char *>(block);
+    auto * buddy_block_data = block_data + block_size / 2;
+
+    auto * memory_block = reinterpret_cast<MemoryBlock *>(block_data);
+    auto * buddy_memory_block = reinterpret_cast<MemoryBlock *>(buddy_block_data);
+
+    return {memory_block, buddy_memory_block};
+}
+
+BuddyArena::MemoryBlock * BuddyArena::mergeWithBuddy(MemoryBlock * block, MemoryBlock * buddy)
+{
+    assert(block);
+    assert(buddy);
+
+    auto * block_data = reinterpret_cast<char *>(block);
+    auto * buddy_block_data = reinterpret_cast<char *>(buddy);
+
+    if (block_data < buddy_block_data) 
+        return reinterpret_cast<MemoryBlock *>(block_data);
+    else 
+        return reinterpret_cast<MemoryBlock *>(buddy_block_data);
+}
+
+BuddyArena::MemoryBlock * BuddyArena::getBuddy(MemoryBlock * block, size_t level) const 
+{
+    auto index_in_level = calculateIndexInLevel(block, level);
+    size_t buddy_index_in_level = index_in_level % 2 == 0 ? index_in_level + 1 : index_in_level - 1;
+    return blockFromIndexInLevel(buddy_index_in_level, level);
+}
+
+BuddyArena::BlockStatus BuddyArena::getBlockStatus(const MemoryBlock * block, size_t level) const
+{
+    auto index_of_block = calculateIndex(block, level);
+    return block_status[index_of_block];
+}
+
+void BuddyArena::setBlockStatus(const MemoryBlock * block, size_t level, BlockStatus status)
+{
+    auto index_of_block = calculateIndex(block, level);
+    block_status[index_of_block] = status; 
+}
+
+void BuddyArena::printMemoryUsageDummy() const 
+{
+    auto occupied_blocks = min_blocks_num - free_min_blocks;
+    double usage = static_cast<double>(occupied_blocks) / min_blocks_num * 100.0;
+    std::cout << "***Memory usage: " << occupied_blocks << " / " << min_blocks_num << " (" << std::fixed << std::setprecision(1) << usage << " %)***" << std::endl;
+}
+
+void BuddyArena::addToList(MemoryBlock ** lists, MemoryBlock * block, size_t level)
+{
+    auto & list = lists[level];
+
+    if (list) 
+    {
+        block->pointers.next = list;
+        block->pointers.previous = nullptr;
+        list->pointers.previous = block;
+    } else 
+    {
+        block->pointers.next = nullptr;
+        block->pointers.previous = nullptr;
+    }
+
+    list = block;
+}
+
+bool BuddyArena::isListEmpty(MemoryBlock ** lists, size_t level)
+{
+    return lists[level] == nullptr;
+}
+
+void BuddyArena::removeFromList(MemoryBlock ** lists, MemoryBlock * block, size_t level)
+{
+    assert(!isListEmpty(lists, level));
+
+    if (block->pointers.next) 
+        block->pointers.next->pointers.previous = block->pointers.previous;
+
+    if (block->pointers.previous) 
+        block->pointers.previous->pointers.next = block->pointers.next;
+
+    /// Move the end of the list if we delete it
+    if (block == lists[level]) 
+        lists[level] = block->pointers.next;
+
+    block->pointers.next = nullptr;
+    block->pointers.previous = nullptr;
+}
+
+
+MemoryBlock::MemoryBlock(size_t size_) : size(size_), is_owner(true)
 {
     ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (MAP_FAILED == ptr)
         DB::throwFromErrno(fmt::format("BlockCache: Cannot mmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY);
 }
 
+MemoryBlock::MemoryBlock(void * ptr_, size_t size_) : ptr(ptr_), size(size_), is_owner(false)
+{}
+
 MemoryBlock::~MemoryBlock()
 {
-    if (ptr && 0 != munmap(ptr, size))
+    if (is_owner && ptr && 0 != munmap(ptr, size))
         DB::throwFromErrno(fmt::format("BlockCache: Cannot munmap {}.", ReadableSize(size)), DB::ErrorCodes::CANNOT_MUNMAP);
 }
 
@@ -110,39 +657,34 @@ static size_t roundUp(size_t x, size_t rounding)
 }
 
 template <typename Key>
-typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::allocate(size_t size, std::lock_guard<std::mutex> & cache_lock)
+typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::allocate(size_t size)
 {
     size = roundUp(size, alignment);
 
     /// Fast path. Look up to size multimap to find free region of specified size.
-    auto it = size_multimap.lower_bound(size, RegionCompareBySize());
-    if (size_multimap.end() != it)
-        return allocateFromFreeRegion(&*it, size, cache_lock);
-
-    /// If nothing was found, ask for rebalancing and check again for the space
-    if (rebalance_strategy) 
     {
-        rebalance_strategy->shouldRebalance(name, size, cache_lock);
+        std::lock_guard cache_lock(mutex);
+        auto it = size_multimap.lower_bound(size, RegionCompareBySize());
+        if (size_multimap.end() != it)
+            return allocateFromFreeRegion(&*it, size, cache_lock);
+    }
+
+    /// Slow path. If nothing was found, ask for rebalancing and check again for the space
+    if (rebalance_strategy) 
+        rebalance_strategy->shouldRebalance(name, size);
+
+    std::lock_guard cache_lock(mutex);
+
+    if (rebalance_strategy)
+    {
+        /// Check again for free blocks
         auto rebalanced_it = size_multimap.lower_bound(size, RegionCompareBySize());
         if (size_multimap.end() != rebalanced_it)
             return allocateFromFreeRegion(&*rebalanced_it, size, cache_lock);
     }
 
-    /// Start evictions
-    while (true)
-    {
-        RegionMetadata * res = evictSome(size, cache_lock);
-
-        /// Nothing to evict. All cache is full and in use - cannot allocate memory.
-        if (!res)
-            return nullptr;
-
-        /// Not enough. Evict more.
-        if (res->size < size)
-            continue;
-
-        return allocateFromFreeRegion(res, size, cache_lock);
-    }
+    /// Nothing works. Start evictions
+    return evict(size, cache_lock);
 }
 
 template <typename Key>
@@ -224,6 +766,25 @@ typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::evictSome(size_t req
             it->memory_block != evicted_region.memory_block || 
             !it->LRUListHook::is_linked())
             return &evicted_region;
+    }
+}
+
+template <typename Key>
+typename BlockCache<Key>::RegionMetadata * BlockCache<Key>::evict(size_t requested_size, std::lock_guard<std::mutex> & cache_lock) noexcept
+{
+    while (true)
+    {
+        RegionMetadata * res = evictSome(requested_size, cache_lock);
+
+        /// Nothing to evict. All cache is full and in use - cannot allocate memory.
+        if (!res)
+            return nullptr;
+
+        /// Not enough. Evict more.
+        if (res->size < requested_size)
+            continue;
+
+        return allocateFromFreeRegion(res, requested_size, cache_lock);
     }
 }
 
@@ -353,18 +914,56 @@ void BlockCache<Key>::addNewMemoryBlocks(MemoryBlockList & memory_blocks)
 }
 
 
+void RebalanceStrategySettings::set(const std::string & key, const Field & field)
+{
+    rebalance_strategy_settings.emplace(std::make_pair(key, field));
+}
+
+void RebalanceStrategySettings::setBlockCacheSetting(
+    const std::string & key, 
+    const std::string & block_cache_name, 
+    const Field & field)
+{
+    block_caches_settings[block_cache_name].emplace(std::make_pair(key, field));
+}
+
+bool RebalanceStrategySettings::tryGet(const std::string & key, Field & field) const 
+{
+    auto it = rebalance_strategy_settings.find(key);
+    if (it == rebalance_strategy_settings.end())
+        return false;
+
+    field = (*it).second;
+    return true; 
+}
+
+bool RebalanceStrategySettings::tryGetBlockCacheSetting(
+    const std::string & key, 
+    const std::string & block_cache_name, 
+    Field & field) const 
+{
+    auto block_cache_it = block_caches_settings.find(block_cache_name);
+    if (block_cache_it == block_caches_settings.end())
+        return false;
+
+    const auto & block_cache_settings = block_cache_it->second;
+    auto it = block_cache_settings.find(key);
+    if (it == block_cache_settings.end())
+        return false;
+
+    field = (*it).second;
+    return true;
+}
+
+
 template <typename Key>
 DummyRebalanceStrategy<Key>::DummyRebalanceStrategy(
-    BlockCacheMapping & caches_, 
-    const BlockCacheSettingsMapping & cache_settings)
+    BlockCacheMapping & caches_, const std::vector<std::string> & block_cache_names_)
     : Base(caches_)
+    , block_cache_names(block_cache_names_)
 {
-    for (const auto & item : cache_settings)
-    {
-        const auto & cache_name = item.first;
-        const auto & cache_setting = item.second;
-        block_cache_stats.try_emplace(cache_name, cache_setting);
-    }
+    for (const auto & cache_name : block_cache_names)
+        block_cache_stats.try_emplace(cache_name);
 }
 
 template <typename Key>
@@ -375,19 +974,21 @@ MemoryBlockList DummyRebalanceStrategy<Key>::initialize(const std::string & /*ca
 }
 
 template <typename Key>
-void DummyRebalanceStrategy<Key>::shouldRebalance(const std::string &caller_name, size_t new_item_size, std::lock_guard<std::mutex> &cache_lock)
+void DummyRebalanceStrategy<Key>::shouldRebalance(const std::string &caller_name, size_t new_item_size)
 {
     assert(block_cache_stats.count(caller_name) != 0);
     size_t page_size = static_cast<size_t>(::getPageSize());
-    size_t required_block_size = std::max(min_memory_block_size, roundUp(new_item_size, page_size));
-    auto & stats_entry = block_cache_stats[caller_name];
-    if (stats_entry.total_memory_blocks_size + required_block_size <= stats_entry.max_total_size) 
+    size_t required_block_size = std::max(Settings::min_memory_block_size, roundUp(new_item_size, page_size));
+
+    const auto & settings_entry = settings.block_cache_settings.at(caller_name);
+    auto & stats_entry = block_cache_stats.at(caller_name);
+    if (stats_entry.total_memory_blocks_size + required_block_size <= settings_entry.max_total_size) 
     {
         auto * block = MemoryBlock::create(required_block_size);
         MemoryBlockList memory_blocks; 
         memory_blocks.push_back(*block);
-        Base::caches.at(caller_name).addNewMemoryBlocks(memory_blocks, cache_lock);
-        stats_entry.total_memory_blocks_size += required_block_size;
+        Base::caches.at(caller_name).addNewMemoryBlocks(memory_blocks);
+        stats_entry.total_memory_blocks_size.fetch_add(required_block_size, std::memory_order_relaxed);
     }
 }
 
@@ -396,14 +997,33 @@ void DummyRebalanceStrategy<Key>::finalize(const std::string &caller_name, Memor
 {
     assert(block_cache_stats.count(caller_name) != 0);
     memory_blocks.clear_and_dispose([](MemoryBlock * block) { block->destroy(); });
-    block_cache_stats[caller_name].total_memory_blocks_size = 0;
+    block_cache_stats[caller_name].total_memory_blocks_size.store(0, std::memory_order_relaxed);
+}
+
+template <typename Key>
+void DummyRebalanceStrategy<Key>::initializeWithSettings(const RebalanceStrategySettings & settings_)
+{
+    Field field;
+    for (const auto & cache_name : block_cache_names) {
+        size_t current_max_total_size = 0;
+        size_t current_max_size_to_evict_on_purging = 0;
+
+        if (settings_.tryGetBlockCacheSetting("max_total_size", cache_name, field))
+            current_max_total_size = field.safeGet<size_t>();
+
+        if (settings_.tryGetBlockCacheSetting("max_size_to_evict_on_purging", cache_name, field))
+            current_max_size_to_evict_on_purging = field.safeGet<size_t>();
+        
+        settings.block_cache_settings.try_emplace(cache_name, current_max_total_size, current_max_size_to_evict_on_purging);
+    }
 }
 
 template <typename Key>
 size_t DummyRebalanceStrategy<Key>::getWeight() const
 {
     size_t total_weight = 0;
-    for (const auto & item : Base::caches) {
+    for (const auto & item : Base::caches) 
+    {
         const auto & block_cache = item.second;
         total_weight += block_cache.getCacheWeight();
     }
@@ -414,7 +1034,8 @@ template <typename Key>
 size_t DummyRebalanceStrategy<Key>::getCount() const
 {
     size_t total_count = 0;
-    for (const auto & item : Base::caches) {
+    for (const auto & item : Base::caches) 
+    {
         const auto & block_cache = item.second;
         total_count += block_cache.getCacheCount();
     }
@@ -424,74 +1045,119 @@ size_t DummyRebalanceStrategy<Key>::getCount() const
 template <typename Key>
 void DummyRebalanceStrategy<Key>::purge()
 {
-    for (const auto & item : block_cache_stats) 
-    {
-        const auto & name = item.first;
-        const auto & cache_stats = item.second;
-        if (cache_stats.max_size_to_evict_on_purging > 0)
-        {
-            auto blocks = Base::caches.at(name).takeMemoryBlocks(cache_stats.max_size_to_evict_on_purging);
-            size_t evicted_size = 0;
-            blocks.clear_and_dispose([&evicted_size](MemoryBlock * block) 
-            { 
-                evicted_size += block->size;
-                block->destroy(); 
-            });
-            block_cache_stats.at(name).total_memory_blocks_size -= evicted_size;
-        }
-    }
+    shrinkBlockCaches(/*use_limit = */true);
 }
 
 template <typename Key>
 void DummyRebalanceStrategy<Key>::reset()
 {
-    for (const auto & item : block_cache_stats) 
+    shrinkBlockCaches(/*use_limit = */false);
+}
+
+template <typename Key>
+void DummyRebalanceStrategy<Key>::shrinkBlockCaches(bool use_limit)
+{
+    for (auto & item : block_cache_stats) 
     {
         const auto & name = item.first;
-        const auto & cache_stats = item.second;
-        auto blocks = Base::caches.at(name).takeMemoryBlocks(cache_stats.max_total_size);
-        blocks.clear_and_dispose([](MemoryBlock * block) { block->destroy(); });
+        auto & cache_stats = item.second;
+        const auto & cache_settings = settings.block_cache_settings.at(name);
+        const auto eviction_limit = use_limit? cache_settings.max_size_to_evict_on_purging : cache_settings.max_total_size;
+
+        auto blocks = Base::caches.at(name).takeMemoryBlocks(eviction_limit);
+        size_t evicted_size = 0;
+        blocks.clear_and_dispose([&evicted_size](MemoryBlock * block) 
+        { 
+            evicted_size += block->size;
+            block->destroy(); 
+        });
+        cache_stats.total_memory_blocks_size.fetch_sub(evicted_size, std::memory_order_relaxed);
     }
 }
 
 
 template <typename Key>
-BuddyRebalanceStrategy<Key>::BuddyRebalanceStrategy(
+BuddyStaticRebalanceStrategy<Key>::BuddyStaticRebalanceStrategy(
     BlockCacheMapping & caches_, 
-    const BlockCacheSettingsMapping & cache_settings)
+    const std::vector<std::string> & block_cache_names_)
     : Base(caches_)
+    , block_cache_names(block_cache_names_)
 {
-    for (const auto & item : cache_settings)
-    {
-        const auto & cache_name = item.first;
-        const auto & cache_setting = item.second;
-        block_cache_stats.try_emplace(cache_name, cache_setting);
-    }
+    for (const auto & cache_name : block_cache_names)
+        block_cache_stats.try_emplace(cache_name);
 }
 
 template <typename Key>
-MemoryBlockList BuddyRebalanceStrategy<Key>::initialize(const std::string & /*caller_name*/) 
+MemoryBlockList BuddyStaticRebalanceStrategy<Key>::initialize(const std::string & /*caller_name*/) 
 {
     // nop
     return {};
 }
 
 template <typename Key>
-void BuddyRebalanceStrategy<Key>::shouldRebalance(const std::string &/*caller_name*/, size_t /*new_item_size*/, std::lock_guard<std::mutex> &/*cache_lock*/)
+void BuddyStaticRebalanceStrategy<Key>::shouldRebalance(const std::string & caller_name, size_t new_item_size)
 {
+    assert(block_cache_stats.count(caller_name) != 0);
+
+    size_t required_block_size = roundUpToPowerOf2(new_item_size, Settings::minimal_allocation_size);
+    auto & stats_entry = block_cache_stats[caller_name];
+
+    auto * block_ptr = memory_arena.malloc(required_block_size);
+    if (block_ptr == nullptr)
+    {
+        std::cerr << "Cannot allocate a block with size " << required_block_size << std::endl;
+        return;
+    }
+
+    auto * block = MemoryBlock::create(block_ptr, required_block_size);
+
+    MemoryBlockList memory_blocks; 
+    memory_blocks.push_back(*block);
+    Base::caches.at(caller_name).addNewMemoryBlocks(memory_blocks);
+
+    stats_entry.total_memory_blocks_size.fetch_add(required_block_size, std::memory_order_relaxed);
 }
 
 template <typename Key>
-void BuddyRebalanceStrategy<Key>::finalize(const std::string &/*caller_name*/, MemoryBlockList /*memory_blocks*/)
+void BuddyStaticRebalanceStrategy<Key>::finalize(const std::string & caller_name, MemoryBlockList memory_blocks)
 {
-
+    assert(block_cache_stats.count(caller_name) != 0);
+    memory_blocks.clear_and_dispose([this](MemoryBlock * block) 
+    { 
+        memory_arena.free(block->ptr);
+        block->destroy(); 
+    });
+    block_cache_stats[caller_name].total_memory_blocks_size.store(0, std::memory_order_relaxed);
 }
 
 template <typename Key>
-size_t BuddyRebalanceStrategy<Key>::getWeight() const
+void BuddyStaticRebalanceStrategy<Key>::initializeWithSettings(const RebalanceStrategySettings & settings_)
+{
+    Field field;
+    /// Initialize a rebalance strategy setting
+    if (settings_.tryGet("memory_arena_size", field))
+        settings.memory_arena_size = field.safeGet<size_t>();
+
+    /// Initialize block cache settings
+    for (const auto & cache_name : block_cache_names) {
+        size_t current_max_size_to_evict_on_purging = 0;
+
+        if (settings_.tryGetBlockCacheSetting("max_size_to_evict_on_purging", cache_name, field))
+            current_max_size_to_evict_on_purging = field.safeGet<size_t>();
+        
+        settings.block_cache_settings.try_emplace(cache_name, current_max_size_to_evict_on_purging);
+    }
+
+    /// Initialize the memory arena
+    memory_arena.initialize(Settings::minimal_allocation_size, settings.memory_arena_size, settings.memory_arena_size);
+}
+
+template <typename Key>
+size_t BuddyStaticRebalanceStrategy<Key>::getWeight() const
 {
     size_t total_weight = 0;
-    for (const auto & item : Base::caches) {
+    for (const auto & item : Base::caches) 
+    {
         const auto & block_cache = item.second;
         total_weight += block_cache.getCacheWeight();
     }
@@ -499,10 +1165,11 @@ size_t BuddyRebalanceStrategy<Key>::getWeight() const
 }
 
 template <typename Key>
-size_t BuddyRebalanceStrategy<Key>::getCount() const
+size_t BuddyStaticRebalanceStrategy<Key>::getCount() const
 {
     size_t total_count = 0;
-    for (const auto & item : Base::caches) {
+    for (const auto & item : Base::caches) 
+    {
         const auto & block_cache = item.second;
         total_count += block_cache.getCacheCount();
     }
@@ -510,15 +1177,205 @@ size_t BuddyRebalanceStrategy<Key>::getCount() const
 }
 
 template <typename Key>
-void BuddyRebalanceStrategy<Key>::purge()
+void BuddyStaticRebalanceStrategy<Key>::purge()
 {
-
+    shrinkBlockCaches(/*use_limit = */true);
 }
 
 template <typename Key>
-void BuddyRebalanceStrategy<Key>::reset()
+void BuddyStaticRebalanceStrategy<Key>::reset()
 {
+    shrinkBlockCaches(/*use_limit = */false);
+}
 
+template <typename Key>
+void BuddyStaticRebalanceStrategy<Key>::shrinkBlockCaches(bool use_limit)
+{
+    for (auto & item : block_cache_stats) 
+    {
+        const auto & name = item.first;
+        auto & cache_stats = item.second;
+        const auto & cache_settings = settings.block_cache_settings.at(name);
+        const auto eviction_limit = use_limit? cache_settings.max_size_to_evict_on_purging : settings.memory_arena_size;
+
+        auto blocks = Base::caches.at(name).takeMemoryBlocks(eviction_limit);
+        size_t evicted_size = 0;
+        blocks.clear_and_dispose([this, &evicted_size](MemoryBlock * block) 
+        { 
+            evicted_size += block->size;
+            memory_arena.free(block->ptr);
+            block->destroy(); 
+        });
+        cache_stats.total_memory_blocks_size.fetch_sub(evicted_size, std::memory_order_relaxed);
+    }
+}
+
+
+template <typename Key>
+BuddyDynamicRebalanceStrategy<Key>::BuddyDynamicRebalanceStrategy(
+    BlockCacheMapping & caches_, 
+    const std::vector<std::string> & block_cache_names_)
+    : Base(caches_)
+    , block_cache_names(block_cache_names_)
+{
+    for (const auto & cache_name : block_cache_names)
+        block_cache_stats.try_emplace(cache_name);
+}
+
+template <typename Key>
+MemoryBlockList BuddyDynamicRebalanceStrategy<Key>::initialize(const std::string & /*caller_name*/) 
+{
+    // nop
+    return {};
+}
+
+template <typename Key>
+void BuddyDynamicRebalanceStrategy<Key>::shouldRebalance(const std::string & caller_name, size_t new_item_size)
+{
+    assert(block_cache_stats.count(caller_name) != 0);
+    size_t required_block_size = roundUpToPowerOf2(new_item_size, Settings::minimal_allocation_size);
+
+    /// Try to steal free memory blocks from other cache pools
+    MemoryBlockList stolen_memory_blocks;
+    {
+        std::lock_guard lock(stealing_mutex);
+        for (auto & item : Base::caches) 
+        {
+            const auto & name = item.first;
+            if (name == caller_name) 
+                continue;
+            auto & block_cache = item.second;
+
+            size_t initial_size = block_cache.getCacheWeight();
+            auto blocks = block_cache.takeMemoryBlocks(0);
+            stolen_memory_blocks.splice(stolen_memory_blocks.end(), blocks);
+            size_t after_steal_size = block_cache.getCacheWeight();
+            assert(initial_size >= after_steal_size);
+
+            auto & stats_entry = block_cache_stats[name];
+            stats_entry.total_memory_blocks_size.fetch_sub(initial_size - after_steal_size, std::memory_order_relaxed);
+        }
+    }
+
+    /// Return all stealt blocks to the BuddyArena
+    stolen_memory_blocks.clear_and_dispose([this](MemoryBlock * block) 
+    { 
+        memory_arena.free(block->ptr);
+        block->destroy(); 
+    });
+
+    /// Take memory from the BuddyArena
+    auto * block_ptr = memory_arena.malloc(settings.allocated_memory_multiplier * required_block_size);
+    if (block_ptr == nullptr)
+        return;
+
+    auto * block = MemoryBlock::create(block_ptr, required_block_size);
+
+    /// Add it to the cache pool
+    MemoryBlockList memory_blocks; 
+    memory_blocks.push_back(*block);
+    Base::caches.at(caller_name).addNewMemoryBlocks(memory_blocks);
+
+    auto & stats_entry = block_cache_stats[caller_name];
+    stats_entry.total_memory_blocks_size.fetch_add(required_block_size, std::memory_order_relaxed);
+}
+
+template <typename Key>
+void BuddyDynamicRebalanceStrategy<Key>::finalize(const std::string & caller_name, MemoryBlockList memory_blocks)
+{
+    assert(block_cache_stats.count(caller_name) != 0);
+    memory_blocks.clear_and_dispose([this](MemoryBlock * block) 
+    { 
+        memory_arena.free(block->ptr);
+        block->destroy(); 
+    });
+    block_cache_stats[caller_name].total_memory_blocks_size.store(0, std::memory_order_relaxed);
+}
+
+template <typename Key>
+void BuddyDynamicRebalanceStrategy<Key>::initializeWithSettings(const RebalanceStrategySettings & settings_)
+{
+    Field field;
+    /// Initialize a rebalance strategy setting
+    if (settings_.tryGet("memory_arena_capacity", field))
+        settings.memory_arena_capacity = field.safeGet<size_t>();
+    
+    if (settings_.tryGet("memory_arena_initial_size", field))
+        settings.memory_arena_initial_size = field.safeGet<size_t>();
+
+    if (settings_.tryGet("allocated_memory_multiplier", field))
+        settings.allocated_memory_multiplier = field.safeGet<size_t>();
+
+    /// Initialize block cache settings
+    for (const auto & cache_name : block_cache_names) {
+        size_t current_max_size_to_evict_on_purging = 0;
+
+        if (settings_.tryGetBlockCacheSetting("max_size_to_evict_on_purging", cache_name, field))
+            current_max_size_to_evict_on_purging = field.safeGet<size_t>();
+        
+        settings.block_cache_settings.try_emplace(cache_name, current_max_size_to_evict_on_purging);
+    }
+
+    /// Initialize the memory arena
+    memory_arena.initialize(Settings::minimal_allocation_size, settings.memory_arena_initial_size, settings.memory_arena_capacity);
+}
+
+template <typename Key>
+size_t BuddyDynamicRebalanceStrategy<Key>::getWeight() const
+{
+    size_t total_weight = 0;
+    for (const auto & item : Base::caches) 
+    {
+        const auto & block_cache = item.second;
+        total_weight += block_cache.getCacheWeight();
+    }
+    return total_weight;
+}
+
+template <typename Key>
+size_t BuddyDynamicRebalanceStrategy<Key>::getCount() const
+{
+    size_t total_count = 0;
+    for (const auto & item : Base::caches) 
+    {
+        const auto & block_cache = item.second;
+        total_count += block_cache.getCacheCount();
+    }
+    return total_count;
+}
+
+template <typename Key>
+void BuddyDynamicRebalanceStrategy<Key>::purge()
+{
+    shrinkBlockCaches(/*use_limit = */true);
+}
+
+template <typename Key>
+void BuddyDynamicRebalanceStrategy<Key>::reset()
+{
+    shrinkBlockCaches(/*use_limit = */false);
+}
+
+template <typename Key>
+void BuddyDynamicRebalanceStrategy<Key>::shrinkBlockCaches(bool use_limit)
+{
+    for (auto & item : block_cache_stats) 
+    {
+        const auto & name = item.first;
+        auto & cache_stats = item.second;
+        const auto & cache_settings = settings.block_cache_settings.at(name);
+        const auto eviction_limit = use_limit? cache_settings.max_size_to_evict_on_purging : settings.memory_arena_capacity;
+
+        auto blocks = Base::caches.at(name).takeMemoryBlocks(eviction_limit);
+        size_t evicted_size = 0;
+        blocks.clear_and_dispose([this, &evicted_size](MemoryBlock * block) 
+        { 
+            evicted_size += block->size;
+            memory_arena.free(block->ptr);
+            block->destroy(); 
+        });
+        cache_stats.total_memory_blocks_size.fetch_sub(evicted_size, std::memory_order_relaxed);
+    }
 }
 
 
@@ -526,16 +1383,22 @@ template <typename Key>
 void BlockCachesManager<Key>::initialize(
     const std::vector<std::string> & block_cache_names,
     std::string_view rebalance_strategy_name,
-    const BlockCacheSettingsMapping & cache_settings)
+    const RebalanceStrategySettings & rebalance_strategy_settings)
 {
-    if (rebalance_strategy_name.empty()) {
+    std::cerr << "Rebalance strategy name: " << rebalance_strategy_name << std::endl;
+    if (rebalance_strategy_name.empty()) 
         rebalance_strategy_name = default_rebalance_strategy;
-    } 
-    if (rebalance_strategy_name == "dummy") {
-        rebalance_strategy = std::make_shared<DummyRebalanceStrategy<Key>>(block_caches, cache_settings);
-    } else {
+
+    if (rebalance_strategy_name == "dummy")
+        rebalance_strategy = std::make_shared<DummyRebalanceStrategy<Key>>(block_caches, block_cache_names);
+    else if (rebalance_strategy_name == "buddy_static")
+        rebalance_strategy = std::make_shared<BuddyStaticRebalanceStrategy<Key>>(block_caches, block_cache_names);
+    else if (rebalance_strategy_name == "buddy_dynamic")
+        rebalance_strategy = std::make_shared<BuddyDynamicRebalanceStrategy<Key>>(block_caches, block_cache_names);
+    else
         throw Exception("Invalid rebalance strategy name", ErrorCodes::BAD_ARGUMENTS);
-    }
+
+    rebalance_strategy->initializeWithSettings(rebalance_strategy_settings);
 
     /// Populate block_caches mapping, the key is block_cache_name and block_cache_name with rebalance_strategy are provided in the constructor 
     for (const auto & block_cache_name : block_cache_names)

--- a/src/Common/UnifiedCache.h
+++ b/src/Common/UnifiedCache.h
@@ -1,0 +1,368 @@
+#pragma once
+
+#include <Common/ArrayCache.h>
+#include <Core/Block.h>
+#include <Core/Types.h>
+#include <Interpreters/Context.h>
+#include <atomic>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/set.hpp>
+#include <boost/core/noncopyable.hpp>
+
+namespace DB
+{
+
+template <typename Key>
+class BlockCache : private boost::noncopyable
+{
+private:
+    struct LRUListTag;
+    struct AdjacencyListTag;
+    struct SizeMultimapTag;
+    struct KeyMapTag;
+
+    using LRUListHook = boost::intrusive::list_base_hook<boost::intrusive::tag<LRUListTag>>;
+    using AdjacencyListHook = boost::intrusive::list_base_hook<boost::intrusive::tag<AdjacencyListTag>>;
+    using SizeMultimapHook = boost::intrusive::set_base_hook<boost::intrusive::tag<SizeMultimapTag>>;
+    using KeyMapHook = boost::intrusive::set_base_hook<boost::intrusive::tag<KeyMapTag>>;
+
+    struct RegionMetadata : public LRUListHook, AdjacencyListHook, SizeMultimapHook, KeyMapHook
+    {
+        Key key;
+
+        union
+        {
+            void * ptr;
+            char * char_ptr;
+        };
+        size_t size;
+        size_t refcount = 0;
+        void * chunk;
+
+        bool operator< (const RegionMetadata & other) const { return size < other.size; }
+
+        bool isFree() const { return SizeMultimapHook::is_linked(); }
+
+        static RegionMetadata * create()
+        {
+            return new RegionMetadata;
+        }
+
+        void destroy()
+        {
+            delete this;
+        }
+
+    private:
+        RegionMetadata() = default;
+        ~RegionMetadata() = default;
+    };
+
+    struct RegionCompareBySize
+    {
+        bool operator() (const RegionMetadata & a, const RegionMetadata & b) const { return a.size < b.size; }
+        bool operator() (const RegionMetadata & a, size_t size) const { return a.size < size; }
+        bool operator() (size_t size, const RegionMetadata & b) const { return size < b.size; }
+    };
+
+    struct RegionCompareByKey
+    {
+        bool operator() (const RegionMetadata & a, const RegionMetadata & b) const { return a.key < b.key; }
+        bool operator() (const RegionMetadata & a, Key key) const { return a.key < key; }
+        bool operator() (Key key, const RegionMetadata & b) const { return key < b.key; }
+    };
+
+    // TODO: boost::intrusize::unordered_set?
+    using LRUList = boost::intrusive::list<RegionMetadata,
+        boost::intrusive::base_hook<LRUListHook>, boost::intrusive::constant_time_size<true>>;
+    using AdjacencyList = boost::intrusive::list<RegionMetadata,
+        boost::intrusive::base_hook<AdjacencyListHook>, boost::intrusive::constant_time_size<true>>;
+    using SizeMultimap = boost::intrusive::multiset<RegionMetadata,
+        boost::intrusive::compare<RegionCompareBySize>, boost::intrusive::base_hook<SizeMultimapHook>, boost::intrusive::constant_time_size<true>>;
+    using KeyMap = boost::intrusive::set<RegionMetadata,
+        boost::intrusive::compare<RegionCompareByKey>, boost::intrusive::base_hook<KeyMapHook>, boost::intrusive::constant_time_size<true>>;
+
+    /** Each region could be:
+      * - free: not holding any data;
+      * - allocated: having data, addressed by key;
+      * -- allocated, in use: holded externally, could not be evicted;
+      * -- allocated, not in use: not holded, could be evicted.
+      */
+
+    /** Invariants:
+      * adjacency_list contains all regions
+      * size_multimap contains free regions
+      * key_map contains allocated regions
+      * lru_list contains allocated regions, that are not in use
+      */
+
+    LRUList lru_list;
+    AdjacencyList adjacency_list;
+    SizeMultimap size_multimap;
+    KeyMap key_map;
+
+    mutable std::mutex mutex;
+
+    struct Chunk : private boost::noncopyable
+    {
+        void * ptr;
+        size_t size;
+
+        explicit Chunk(size_t size_); 
+
+        ~Chunk();
+
+        Chunk(Chunk && other) noexcept : ptr(other.ptr), size(other.size)
+        {
+            other.ptr = nullptr;
+        }
+    };
+
+    using Chunks = std::list<Chunk>;
+    Chunks chunks;
+
+    size_t max_total_size = 0;
+
+    /// We will allocate memory in chunks of at least that size.
+    /// 64 MB makes mmap overhead comparable to memory throughput.
+    static constexpr size_t min_chunk_size = 64 * 1024 * 1024;
+
+    static constexpr size_t alignment = 16;
+
+    size_t total_chunks_size = 0;
+    std::atomic<size_t> total_useful_cache_size = 0;
+    std::atomic<size_t> total_useful_cache_count = 0;
+ 
+    RegionMetadata * addNewChunk(size_t size);
+    RegionMetadata * allocateFromFreeRegion(RegionMetadata * free_region, size_t size);
+
+    RegionMetadata * allocate(size_t size);
+    void freeRegion(RegionMetadata * region) noexcept;
+
+    void evictRegion(RegionMetadata * evicted_region) noexcept;
+    RegionMetadata * evictSome(size_t requested_size) noexcept;
+
+public:
+    struct Holder : private boost::noncopyable
+    {
+        Holder(BlockCache & cache_, RegionMetadata & region_, std::lock_guard<std::mutex>&);
+        ~Holder();
+
+        void * ptr() 
+        { 
+            assert(region.ptr != nullptr);
+            return region.ptr; 
+        }
+        const void * ptr() const 
+        { 
+            assert(region.ptr != nullptr);
+            return region.ptr; 
+        }
+        size_t size() const { return region.size; }
+        Key key() const { return region.key; }
+
+    private:
+        BlockCache & cache;
+        RegionMetadata & region;
+        void * region_ptr;
+    };
+
+    using HolderPtr = Holder *;
+
+    BlockCache() = default;
+
+    explicit BlockCache(size_t max_total_size_) : max_total_size(max_total_size_)
+    {
+    }
+
+    ~BlockCache();
+
+    void initialize(size_t max_total_size_) { max_total_size = max_total_size_; }
+
+    /// Applications isn't supposed to call these methods directly without 
+    /// proxy classes to hold raw pointers
+    template <typename GetSizeFunc, typename InitializeFunc>
+    HolderPtr getOrSet(const Key & key, 
+                       GetSizeFunc && get_size, 
+                       InitializeFunc && initialize, 
+                       bool * was_calculated)
+    {
+        std::lock_guard cache_lock(mutex);
+
+        auto it = key_map.find(key, RegionCompareByKey());
+        if (key_map.end() != it)
+        {
+            if (was_calculated)
+                *was_calculated = false;
+            return new Holder(*this, *it, cache_lock);
+        }
+
+        size_t size = get_size();
+        RegionMetadata * region = allocate(size);
+
+        if (!region) 
+            return {};
+
+        region->key = key;
+
+        try
+        {
+            initialize(region->ptr);
+        }
+        catch (...)
+        {
+            freeRegion(region);
+            throw;
+        }
+
+        key_map.insert(*region);
+        if (was_calculated)
+            *was_calculated = true;
+
+        /// Statistics
+        if (region) {
+            total_useful_cache_size.fetch_add(size, std::memory_order_relaxed);
+            total_useful_cache_count.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        return new Holder(*this, *region, cache_lock);
+    }
+
+    HolderPtr get(const Key & key);
+
+    void reset();
+
+    bool isValid() const { return max_total_size != 0; }
+
+    size_t getCacheWeight() const;
+
+    size_t getCacheCount() const;
+};
+
+template <typename Key>
+class GlobalBlockCache {
+public:
+    static BlockCache<Key> & instance()
+    {
+        static GlobalBlockCache<Key> holder;
+        return holder.block_cache;
+    }
+
+private:
+    BlockCache<Key> block_cache;
+
+    GlobalBlockCache() = default;
+};
+
+// Unified interface for the access to items from the cache and items not from the cache
+template <typename Payload>
+struct PayloadHolder {
+    PayloadHolder() = default;
+    virtual ~PayloadHolder() = default;
+
+    virtual Payload & payload() = 0;
+    virtual const Payload & payload() const = 0;
+    Payload & operator*() { return payload(); }
+    const Payload & operator*() const { return payload(); }
+
+    /// PayloadHolder should be light-weight and copy- and move-constuctible
+    PayloadHolder(const PayloadHolder&) = default;
+    PayloadHolder& operator=(const PayloadHolder&) = default;
+    PayloadHolder(PayloadHolder&&) noexcept = default;
+    PayloadHolder& operator=(PayloadHolder&&) noexcept = default;
+};
+
+// Simple holder for the pointer with an unified interface with CachePayloadHolder
+// Used to unify access to the cache items and non-cache items
+template <typename Payload>
+struct SharedPayloadHolder : public PayloadHolder<Payload> {
+    /// Adopt payload_ptr_ and own a memory for it
+    explicit SharedPayloadHolder(Payload * payload_ptr_)
+        : payload_ptr(payload_ptr_) 
+    {}
+
+    ~SharedPayloadHolder() override { delete payload_ptr; }
+
+    Payload & payload() override { return *payload_ptr; }
+    const Payload & payload() const override { return *payload_ptr; }
+private:
+    Payload * payload_ptr;
+};
+
+template <typename TKey, typename Payload>
+class UnifiedCacheAdapter {
+public:
+    using Key = TKey; 
+    using HolderPtr = typename BlockCache<Key>::HolderPtr;
+
+    struct CachePayloadHolder : public PayloadHolder<Payload> {
+        /// Adopt holder_ptr_ and own a reference to the memory for it
+        explicit CachePayloadHolder(HolderPtr holder_ptr_)
+            : payload_ptr(reinterpret_cast<Payload *>(holder_ptr_->ptr()))
+            , holder_ptr(std::move(holder_ptr_))
+        {}
+
+        ~CachePayloadHolder() override { delete holder_ptr; }
+
+        Payload & payload() override { return *payload_ptr; }
+        const Payload & payload() const override { return *payload_ptr; }
+    private:
+        Payload * payload_ptr;
+        HolderPtr holder_ptr;
+    };
+
+    using CachePayloadHolderPtr = std::shared_ptr<CachePayloadHolder>;
+
+    UnifiedCacheAdapter() : instance(GlobalBlockCache<Key>::instance())
+    {
+    }
+
+    /// initialize must construct Payload object in the start of the memory block
+    /// get_size must return number of additional bytes that is needed fro the object (except for the object initialization)
+    template <typename GetSizeFunc, typename InitializeFunc>
+    CachePayloadHolderPtr getOrSet(const Key & key, 
+                              GetSizeFunc && get_size, 
+                              InitializeFunc && initialize, 
+                              bool * was_calculated) 
+    {
+        auto get_full_size = [&get_size]() 
+        {
+            return sizeof(Payload) + get_size();
+        };
+        auto * holder_ptr = instance.getOrSet(key, get_full_size, initialize, was_calculated);
+        if (holder_ptr == nullptr) 
+            return nullptr;
+        else
+            return std::make_shared<CachePayloadHolder>(holder_ptr);
+    }
+
+    CachePayloadHolderPtr get(const Key & key)
+    {
+        auto * holder_ptr = instance.get(key);
+        return std::make_shared<CachePayloadHolder>(holder_ptr);
+    }
+
+    void reset()
+    {
+        /// TODO: implement
+    }
+
+    size_t weight() const
+    {
+        /// TODO: implement
+        return 0;
+    }
+
+    size_t count() const
+    {
+        /// TODO: implement
+        return 0;
+    }
+
+private:
+    BlockCache<Key> & instance;
+};
+
+extern template class BlockCache<UInt128>;
+
+}

--- a/src/Compression/CachedCompressedReadBuffer.h
+++ b/src/Compression/CachedCompressedReadBuffer.h
@@ -19,6 +19,9 @@ namespace DB
   */
 class CachedCompressedReadBuffer : public CompressedReadBufferBase, public ReadBuffer
 {
+    using UncompressedCellHolder = PayloadHolder<UncompressedCacheCell>;
+    using UncompressedCellHolderPtr = std::shared_ptr<UncompressedCellHolder>;
+
 private:
     std::function<std::unique_ptr<ReadBufferFromFileBase>()> file_in_creator;
     UncompressedCache * cache;
@@ -30,7 +33,7 @@ private:
     size_t file_pos;
 
     /// A piece of data from the cache, or a piece of read data that we put into the cache.
-    UncompressedCache::MappedPtr owned_cell;
+    UncompressedCellHolderPtr owned_region;
 
     void initInput();
 

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -35,8 +35,7 @@ private:
     using HolderPtr = Base::CachePayloadHolderPtr;
 
 public:
-    // TODO: Remove size and policy parameters from the constructor
-    explicit UncompressedCache(size_t /*max_size_in_bytes*/, const String & /*uncompressed_cache_policy*/ = "")
+    explicit UncompressedCache(const String & block_cache_name) : Base(block_cache_name)
     {}
 
     /// Calculate key from path to file and offset.

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Common/UnifiedCache.h>
 #include <Common/SipHash.h>
 #include <Common/ProfileEvents.h>
 #include <Common/HashTable/Hash.h>
@@ -20,30 +21,23 @@ namespace DB
 
 struct UncompressedCacheCell
 {
-    Memory<> data;
+    char * data;
+    size_t data_size;
     size_t compressed_size;
     UInt32 additional_bytes;
 };
 
-struct UncompressedSizeWeightFunction
-{
-    size_t operator()(const UncompressedCacheCell & x) const
-    {
-        return x.data.size();
-    }
-};
 
-
-/** Cache of decompressed blocks for implementation of CachedCompressedReadBuffer. thread-safe.
-  */
-class UncompressedCache : public CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>
+class UncompressedCache : public UnifiedCacheAdapter<UInt128, UncompressedCacheCell> 
 {
 private:
-    using Base = CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
+    using Base = UnifiedCacheAdapter<UInt128, UncompressedCacheCell>;
+    using HolderPtr = Base::CachePayloadHolderPtr;
 
 public:
-    explicit UncompressedCache(size_t max_size_in_bytes, const String & uncompressed_cache_policy = "")
-        : Base(max_size_in_bytes, 0, uncompressed_cache_policy) {}
+    // TODO: Remove size and policy parameters from the constructor
+    explicit UncompressedCache(size_t /*max_size_in_bytes*/, const String & /*uncompressed_cache_policy*/ = "")
+    {}
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file, size_t offset)
@@ -58,25 +52,29 @@ public:
         return key;
     }
 
-    template <typename LoadFunc>
-    MappedPtr getOrSet(const Key & key, LoadFunc && load)
+    template <typename GetSizeFunc, typename InitializeFunc>
+    HolderPtr getOrSet(const Key & key, GetSizeFunc && get_size, InitializeFunc && initialize)
     {
-        auto result = Base::getOrSet(key, std::forward<LoadFunc>(load));
+        bool was_calculated = false;
+        auto result = Base::getOrSet(key, std::forward<GetSizeFunc>(get_size), std::forward<InitializeFunc>(initialize), &was_calculated);
 
-        if (result.second)
+        if (was_calculated)
             ProfileEvents::increment(ProfileEvents::UncompressedCacheMisses);
         else
             ProfileEvents::increment(ProfileEvents::UncompressedCacheHits);
 
-        return result.first;
+        return result;
     }
 
-private:
-    void onRemoveOverflowWeightLoss(size_t weight_loss) override
-    {
-        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, weight_loss);
-    }
+// TODO: Add support for the ProfileEvents::UncompressedCacheWeightLost
+// private:
+//     void onRemoveOverflowWeightLoss(size_t weight_loss) override
+//     {
+//         ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, weight_loss);
+//     }
 };
+
+
 
 using UncompressedCachePtr = std::shared_ptr<UncompressedCache>;
 

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -620,6 +620,23 @@ void AsynchronousMetrics::update(TimePoint update_time)
         }
     }
 
+    // Temporary add cache tracking
+    // TODO: Remove
+    {
+        auto & unified_cache= GlobalBlockCache<UInt128>::instance();
+        if (unified_cache.isValid())
+        {
+            const auto unified_cache_weight = unified_cache.getCacheWeight();
+            const auto unified_cache_count = unified_cache.getCacheCount();
+            new_values["UnifiedCacheBytes"] = unified_cache_weight;
+            new_values["UnifiedCacheCount"] = unified_cache_count;
+            LOG_TRACE(log,
+                "UnifiedCacheTracking: weight is {}, count is {}",
+                ReadableSize(unified_cache_weight),
+                unified_cache_count);
+        }
+    }
+
 #if USE_ROCKSDB
     {
         if (auto metadata_cache = getContext()->tryGetMergeTreeMetadataCache())

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -11,6 +11,7 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/typeid_cast.h>
 #include <Common/filesystemHelpers.h>
+#include <Common/UnifiedCache.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
 #include <Common/getCurrentProcessFDCount.h>
 #include <Common/getMaxFileDescriptorCount.h>
@@ -623,18 +624,15 @@ void AsynchronousMetrics::update(TimePoint update_time)
     // Temporary add cache tracking
     // TODO: Remove
     {
-        auto & unified_cache= GlobalBlockCache<UInt128>::instance();
-        if (unified_cache.isValid())
-        {
-            const auto unified_cache_weight = unified_cache.getCacheWeight();
-            const auto unified_cache_count = unified_cache.getCacheCount();
-            new_values["UnifiedCacheBytes"] = unified_cache_weight;
-            new_values["UnifiedCacheCount"] = unified_cache_count;
-            LOG_TRACE(log,
-                "UnifiedCacheTracking: weight is {}, count is {}",
-                ReadableSize(unified_cache_weight),
-                unified_cache_count);
-        }
+        auto & unified_cache = BlockCachesManager<UInt128>::instance();
+        const auto unified_cache_weight = unified_cache.getCacheWeight();
+        const auto unified_cache_count = unified_cache.getCacheCount();
+        new_values["UnifiedCacheBytes"] = unified_cache_weight;
+        new_values["UnifiedCacheCount"] = unified_cache_count;
+        LOG_TRACE(log,
+            "UnifiedCacheTracking: weight is {}, count is {}",
+            ReadableSize(unified_cache_weight),
+            unified_cache_count);
     }
 
 #if USE_ROCKSDB

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -625,6 +625,8 @@ void AsynchronousMetrics::update(TimePoint update_time)
     // TODO: Remove
     {
         auto & unified_cache = BlockCachesManager<UInt128>::instance();
+
+        /// Basic tracking
         const auto unified_cache_weight = unified_cache.getCacheWeight();
         const auto unified_cache_count = unified_cache.getCacheCount();
         new_values["UnifiedCacheBytes"] = unified_cache_weight;
@@ -633,6 +635,53 @@ void AsynchronousMetrics::update(TimePoint update_time)
             "UnifiedCacheTracking: weight is {}, count is {}",
             ReadableSize(unified_cache_weight),
             unified_cache_count);
+
+        /// Metrics
+        using RebalanceStrategy = IRebalanceStrategy<UInt128>;
+        using StatRequest = RebalanceStrategy::StatRequest;
+        using StatRequests = RebalanceStrategy::StatRequests;
+
+        StatRequests requests
+        {
+            StatRequest{.block_cache_name = "marks", .stat_name = "should_rebalance_to_stealing_attempts_diff"},
+            StatRequest{.block_cache_name = "uncompressed", .stat_name = "should_rebalance_to_stealing_attempts_diff"},
+            StatRequest{.block_cache_name = "marks", .stat_name = "memory_allocation_failures"},
+            StatRequest{.block_cache_name = "uncompressed", .stat_name = "memory_allocation_failures"},
+            StatRequest{.block_cache_name = "marks", .stat_name = "total_memory_blocks_size"},
+            StatRequest{.block_cache_name = "uncompressed", .stat_name = "total_memory_blocks_size"},
+        };
+        auto responses = unified_cache.getStats(requests);
+
+        LOG_TRACE(log,
+            "UnifiedCacheStats: in {} pool {} is {}",
+            requests[0].block_cache_name,
+            requests[0].stat_name,
+            responses[0].safeGet<Int64>());
+        LOG_TRACE(log,
+            "UnifiedCacheStats: in {} pool {} is {}",
+            requests[1].block_cache_name,
+            requests[1].stat_name,
+            responses[1].safeGet<Int64>());
+        LOG_TRACE(log,
+            "UnifiedCacheStats: in {} pool {} is {}",
+            requests[2].block_cache_name,
+            requests[2].stat_name,
+            responses[2].safeGet<size_t>());
+        LOG_TRACE(log,
+            "UnifiedCacheStats: in {} pool {} is {}",
+            requests[3].block_cache_name,
+            requests[3].stat_name,
+            responses[3].safeGet<size_t>());
+        LOG_TRACE(log,
+            "UnifiedCacheStats: in {} pool {} is {}",
+            requests[4].block_cache_name,
+            requests[4].stat_name,
+            responses[4].safeGet<size_t>());
+        LOG_TRACE(log,
+            "UnifiedCacheStats: in {} pool {} is {}",
+            requests[5].block_cache_name,
+            requests[5].stat_name,
+            responses[5].safeGet<size_t>());
     }
 
 #if USE_ROCKSDB

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1701,14 +1701,14 @@ ProcessList::Element * Context::getProcessListElement() const
 }
 
 
-void Context::setUncompressedCache(size_t max_size_in_bytes, const String & uncompressed_cache_policy)
+void Context::setUncompressedCache(const String & block_cache_name)
 {
     auto lock = getLock();
 
     if (shared->uncompressed_cache)
         throw Exception("Uncompressed cache has been already created.", ErrorCodes::LOGICAL_ERROR);
 
-    shared->uncompressed_cache = std::make_shared<UncompressedCache>(max_size_in_bytes, uncompressed_cache_policy);
+    shared->uncompressed_cache = std::make_shared<UncompressedCache>(block_cache_name);
 }
 
 
@@ -1727,14 +1727,14 @@ void Context::dropUncompressedCache() const
 }
 
 
-void Context::setMarkCache(size_t cache_size_in_bytes, const String & mark_cache_policy)
+void Context::setMarkCache(const String & block_cache_name)
 {
     auto lock = getLock();
 
     if (shared->mark_cache)
         throw Exception("Mark cache has been already created.", ErrorCodes::LOGICAL_ERROR);
 
-    shared->mark_cache = std::make_shared<MarkCache>(cache_size_in_bytes, mark_cache_policy);
+    shared->mark_cache = std::make_shared<MarkCache>(block_cache_name);
 }
 
 MarkCachePtr Context::getMarkCache() const
@@ -1762,14 +1762,14 @@ ThreadPool & Context::getLoadMarksThreadpool() const
     return *shared->load_marks_threadpool;
 }
 
-void Context::setIndexUncompressedCache(size_t max_size_in_bytes)
+void Context::setIndexUncompressedCache(const String & block_cache_name)
 {
     auto lock = getLock();
 
     if (shared->index_uncompressed_cache)
         throw Exception("Index uncompressed cache has been already created.", ErrorCodes::LOGICAL_ERROR);
 
-    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(max_size_in_bytes);
+    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(block_cache_name);
 }
 
 
@@ -1788,14 +1788,14 @@ void Context::dropIndexUncompressedCache() const
 }
 
 
-void Context::setIndexMarkCache(size_t cache_size_in_bytes)
+void Context::setIndexMarkCache(const String & block_cache_name)
 {
     auto lock = getLock();
 
     if (shared->index_mark_cache)
         throw Exception("Index mark cache has been already created.", ErrorCodes::LOGICAL_ERROR);
 
-    shared->index_mark_cache = std::make_shared<MarkCache>(cache_size_in_bytes);
+    shared->index_mark_cache = std::make_shared<MarkCache>(block_cache_name);
 }
 
 MarkCachePtr Context::getIndexMarkCache() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -802,23 +802,23 @@ public:
     void setSystemZooKeeperLogAfterInitializationIfNeeded();
 
     /// Create a cache of uncompressed blocks of specified size. This can be done only once.
-    void setUncompressedCache(size_t max_size_in_bytes, const String & uncompressed_cache_policy);
+    void setUncompressedCache(const String & block_cache_name);
     std::shared_ptr<UncompressedCache> getUncompressedCache() const;
     void dropUncompressedCache() const;
 
     /// Create a cache of marks of specified size. This can be done only once.
-    void setMarkCache(size_t cache_size_in_bytes, const String & mark_cache_policy);
+    void setMarkCache(const String & block_cache_name);
     std::shared_ptr<MarkCache> getMarkCache() const;
     void dropMarkCache() const;
     ThreadPool & getLoadMarksThreadpool() const;
 
     /// Create a cache of index uncompressed blocks of specified size. This can be done only once.
-    void setIndexUncompressedCache(size_t max_size_in_bytes);
+    void setIndexUncompressedCache(const String & block_cache_name);
     std::shared_ptr<UncompressedCache> getIndexUncompressedCache() const;
     void dropIndexUncompressedCache() const;
 
     /// Create a cache of index marks of specified size. This can be done only once.
-    void setIndexMarkCache(size_t cache_size_in_bytes);
+    void setIndexMarkCache(const String & block_cache_name);
     std::shared_ptr<MarkCache> getIndexMarkCache() const;
     void dropIndexMarkCache() const;
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -26,8 +26,7 @@ private:
     using HolderPtr = Base::CachePayloadHolderPtr;
 
 public:
-    // TODO: Remove size and policy parameters from the constructor
-    explicit MarkCache(size_t /*max_size_in_bytes*/, const String & /*mark_cache_policy*/ = "") 
+    explicit MarkCache(const String & block_cache_name) : Base(block_cache_name) 
     {}
 
     /// Calculate key from path to file and offset.

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <Common/UnifiedCache.h>
 #include <Common/CacheBase.h>
 #include <Common/ProfileEvents.h>
 #include <Common/SipHash.h>
@@ -18,30 +19,16 @@ namespace ProfileEvents
 namespace DB
 {
 
-/// Estimate of number of bytes in cache for marks.
-struct MarksWeightFunction
-{
-    /// We spent additional bytes on key in hashmap, linked lists, shared pointers, etc ...
-    static constexpr size_t MARK_CACHE_OVERHEAD = 128;
-
-    size_t operator()(const MarksInCompressedFile & marks) const
-    {
-        return marks.size() * sizeof(MarkInCompressedFile) + MARK_CACHE_OVERHEAD;
-    }
-};
-
-
-/** Cache of 'marks' for StorageMergeTree.
-  * Marks is an index structure that addresses ranges in column file, corresponding to ranges of primary key.
-  */
-class MarkCache : public CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>
+class MarkCache : public UnifiedCacheAdapter<UInt128, MarksInCompressedFile> 
 {
 private:
-    using Base = CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
+    using Base = UnifiedCacheAdapter<UInt128, MarksInCompressedFile>;
+    using HolderPtr = Base::CachePayloadHolderPtr;
 
 public:
-    explicit MarkCache(size_t max_size_in_bytes, const String & mark_cache_policy = "")
-        : Base(max_size_in_bytes, 0, mark_cache_policy) {}
+    // TODO: Remove size and policy parameters from the constructor
+    explicit MarkCache(size_t /*max_size_in_bytes*/, const String & /*mark_cache_policy*/ = "") 
+    {}
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file)
@@ -55,16 +42,17 @@ public:
         return key;
     }
 
-    template <typename LoadFunc>
-    MappedPtr getOrSet(const Key & key, LoadFunc && load)
+    template <typename GetSizeFunc, typename InitializeFunc>
+    HolderPtr getOrSet(const Key & key, GetSizeFunc && get_size, InitializeFunc && initialize)
     {
-        auto result = Base::getOrSet(key, load);
-        if (result.second)
+        bool was_calculated = false;
+        auto result = Base::getOrSet(key, std::forward<GetSizeFunc>(get_size), std::forward<InitializeFunc>(initialize), &was_calculated);
+        if (was_calculated)
             ProfileEvents::increment(ProfileEvents::MarkCacheMisses);
         else
             ProfileEvents::increment(ProfileEvents::MarkCacheHits);
 
-        return result.first;
+        return result;
     }
 };
 


### PR DESCRIPTION
# Summary
Added unified cache memory storage for data caches with an integration of the general-purpose memory allocator. 

- Designed and implemented the universal cache storage
- Integrated MarksCache and UncompressedCache in this storage
- Integrated general-purpose Allocator that can directly use the cache storage
# Features
- Instead of the configuration of the data caches separately, you need to [configure](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1433) the global cache storage
- Each data cache should be [assigned](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1449) to some ```BlockCache``` -- the pool of the similar data caches. The pool has separate memory storage and eviction mechanism.
- The storage of cache pools is managed by ```RebalanceStrategy```, which is a specific algorithm to extend/reduce the sizes of the cache pools. The ```RebalanceStrategy``` is the [point of configuration](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1423) of the cache memory management.
- Some baseline rebalancing strategies are implemented:
   - [Dummy rebalance strategy](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1423). Cache pools can grow indefinitely separately, but the total size of caches in the unified cache storage is bounded. Memory for ```BlockCache``` is allocated through mmap.
   - [Buddy static strategy](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1409). Memory for ```BlockCache``` is allocated through special ```BuddyAllocator``` which is a custom allocator with buddy schema. The size of the memory arena for the allocator is fixed. This rebalance strategy can take memory blocks from one cache pool and add them to another.
   - [Buddy dynamic strategy](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1418). The same as the buddy static strategy, but the size of the memory arena for the allocator is dynamic and can grow up to the absolute limit. 
- The memory tracker can [purge](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-330af1a9f5e0bc78a4831acfc2b01918e1a906d8d4d95ec22f8434dd1c0b4743R1418) the cache storage and free some additional memory for further allocations.
- Buddy dynamic strategy can work with an integration of a general-purpose allocator to the cache storage. It can directly take memory blocks from the evicted cache items.

# Performance
The ClickBench results are shown in the figure below.

![Cold run without populated caches](https://i.imgur.com/mojDgTg.png)
![Hot run with populated caches](https://i.imgur.com/L4Td8nP.png)

Our unified cache storage has a similar performance to the baseline both in cold and hot runs. The same performance in the cold run without populated caches means that there is no significant overhead to the writing to the cache storage, and the same performance in the hot run with populated caches means that there is no significant overhead to the reading from the cache storage. The performance difference over all queries is not greater than 3%.

# Design
## Overview
- The key component is the [```BlockCache```](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-dd5ed200dec8f0cd44d2d6a6387b3fca91d805d0f198200fc15dce8d8727c1cdR209) which is a cache of static memory blocks. This class is based on the existing [```ArrayCache```](https://github.com/ClickHouse/ClickHouse/blob/04a372bf20ddd14c080c3d28504299629d687515/src/Common/ArrayCache.h#L81).
- The unified cache storage consists of cache pools which are separate ```BlockCaches```.
- The cache pools are rebalanced using [```RebalanceStrategy```](https://github.com/NikitaEvs/ClickHouse/pull/2/files#diff-dd5ed200dec8f0cd44d2d6a6387b3fca91d805d0f198200fc15dce8d8727c1cdR603)
## ```BlockCache``` design
![BlockCache-basic](https://i.imgur.com/YOqPUkP.png)

- The ```BlockCache``` stores underlying memory in the form of chunks. 
- ```Chunk``` is an abstraction of the contiguous memory block that is given to the ```BlockCache``` from an external source. The ```BlockCache``` slices a chunk’s memory into parts which are assigned to regions. 
- ```Region``` is part of a chunk that is used as a memory storage for cache items. The metadata of regions is stored in the intrusive list that implements the LRU cache eviction policy. This policy is chosen as a baseline, because it is easy to implement, and it works well enough in most scenarios. 
- Allocations of regions from chunks are served by the allocator that uses a red-black tree to keep free blocks of chunks.

![BlockCache-handler](https://i.imgur.com/XFQTFma.png)

- The ```BlockCache``` provides the memory of regions for cache items, but it must not evict regions which are currently in use to serve as an underlying memory for cache items.
- To track the usage of the memory of regions, the reference counting mechanism is implemented in ```Holder``` which is an access container for regions.
- ```Holder``` provides access to raw memory, but the current data caches do not work directly with raw memory. ```UnifiedCacheAdapter``` is implemented to connect current data caches with raw memory storage provided by ```Holder```.

![BlockCache-dynamic](https://i.imgur.com/vy4BcSA.png)

- The ```BlockCache``` must have dynamically changed underlying memory storage. The ```Chunk``` represents the underlying memory storage, so the ```BlockCache``` must have support for adding chunks to it and taking chunks from it.
- Two lists of chunks are used to implement this support. The first one is the Free list, it stores chunks which do not have any regions placed on them. The second one is the Acquired list, it stores chunks which have at least one region on them.
- If we want to add a new chunk to the ```BlockCache```, we need to add it to the Free list. So we can use chunks from the Free list if we do not have enough free space in chunks in the Acquired list.
- If we want to take a chunk from the ```BlockCache```, we can directly do it from the Free list. This guarantees that we do not take a chunk from the ```BlockCache``` that is currently used for some cache items.

## Dynamic ```BuddyAllocator``` design
We want to allow the general-purpose allocator to take memory from the cache storage, so this requires modification to the general-purpose allocator. As we do not want to modify the external library jemalloc, we implement our allocator schema that can serve as a general-purpose allocator.

We chose the buddy schema among other allocation algorithms because:
- Buddy system has good performance in terms of allocation speed.
- The original Buddy system algorithm is easy to implement as a baseline.
- Internal memory fragmentation is not a big concern for a prototypical implementation of the cache storage and the allocator. This problem will be mitigated using the ```BlockCache``` design.
- We want to use ```BuddyAllocator``` only for the cache items, so we need to add memory shrinkage and growth support in BuddyAllocator, so we can reuse memory from the cache storage for general-purpose allocations and dynamically change the size of the storage.
- The proposed solution is the following:
  1. At the start of the program, define an absolute maximum of memory that can be used by ```BuddyAllocator```.
  2. ```BuddyAllocator``` allocates the absolute maximum of virtual memory without a population of the mapping to the physical memory.
  3. ```BuddyAllocator``` initializes metadata for the whole memory arena.
  4. Shrinking and growth are done with a help of an additional list of freed blocks.
- So the algorithm for memory shrinking is as follows:
  1. For the allocation of the target amount of blocks, we need to remove them from the free lists and mark them as allocated.
  2. Advise the operating system that we do not need a mapping to the physical memory for these blocks.
  3. Add the blocks to the additional lists of freed blocks and change their status.
- The algorithm is similar for memory growth.

## Cache sharding
- The cache pollution problem occurs because of the non-uniform cache items. This problem relates to the unnecessary evictions of many small cache items because of a new big cache item.
- To deal with this problem, we can add the cache storage sharding using cache pools.
- The Cache pool is a separate instance of ```BlockCache``` that serves as cache storage for a group of related data caches.
- As the cache pool has separate memory storage and eviction policy, items from different cache pools do not interfere with each other.
- With a cache sharding approach, there should be a coordinator that manages memory chunks of cache pools. 
- The coordinator in the current design is the rebalance strategy, an abstraction that exchanges chunks between cache pools and some global cache memory storage.
- The method ```initialize``` of the rebalance strategy is called by the cache pool during its initialization. Each cache pool has a unique name, so the rebalance strategy can distinguish cache pools between different calls to its methods. This method allows the rebalance strategy to assign starter memory chunks to the cache pool.
- The method ```finalize``` has similar semantics, but it is needed so that the cache pool can return memory Chunks on its destruction.
- The main purpose of ```shouldRebalance``` is that the cache pool can notify the rebalance strategy about the shortage of memory, so the rebalance strategy can add more chunks or allow evicting some cache items.
- So ```shouldRebalance``` method is integrated into the pipeline of a new
cache entry allocation. 
![Integration of the rebalance strategy into the allocation of a new cache entry](https://i.imgur.com/QC4M6YS.png)
- The rebalance strategy can utilize different statistics from cache pools such as the size of their local storage, hit/miss ratio, and mean lifetime of cache items. The development of a good rebalance strategy
is a space for further research.
- One of the developed rebalance strategies, the dynamic buddy rebalance strategy, uses ```BuddyAllocator``` as the source of chunks for cache pools.
- The rebalancing strategy can shrink cache pools to return more memory in the ```BuddyAllocator```, and then ```BuddyAllocator``` can also shrink itself to return memory to the operating system, or ```BuddyAllocator``` can serve allocations directly as a general-purpose allocator.
- Dynamic buddy rebalancing strategy implements the following ```shouldRebalance``` algorithm:
  1. Take all free memory chunks from other cache pools.
  2. Return them to the BuddyAllocator, so contiguous blocks will be merged.
  3. Take the target amount of memory from BuddyAllocator. 
  4. Make a chunk using this memory.
  5. Add this chunk to the caller cache pool.
 
 ![Final design](https://i.imgur.com/GlVtpf1.png)
# Future work
- Development of new rebalance strategies. An example of a new rebalance strategy is the strategy that tries to optimize the overall hit ratio rather than ensuring fairness between cache pools. Using cache pool statistics, we can also optimize the cache usage under different work conditions.
- Integration of modern cache eviction policies, such as ARC, in the ```BlockCache```.
- Optimization of the allocator used for the rebalance strategy. While the buddy schema is a good baseline, further research can develop a more scalable system.
- Advanced cache and memory allocator benchmarking.

# Additional information
This work was part of my bachelor's [thesis](https://drive.google.com/file/d/1JcBRzesNzicEoz8zBsamUu2HX3d5buAc/view?usp=sharing).
You can also check the [slides](https://docs.google.com/presentation/d/1Z42nq_PUeKt3HygHLcu-OFaCoCQLZV0RNe1Eaop9yhY/edit?usp=sharing) from the project presentation.